### PR TITLE
Upgrade to dotnet8

### DIFF
--- a/CalcExpr/Attributes/ReferenceRuleAttribute.cs
+++ b/CalcExpr/Attributes/ReferenceRuleAttribute.cs
@@ -1,4 +1,5 @@
 ﻿namespace CalcExpr.Attributes;
 
+[AttributeUsage(AttributeTargets.Class)]
 public class ReferenceRuleAttribute : Attribute
 { }

--- a/CalcExpr/CalcExpr.csproj
+++ b/CalcExpr/CalcExpr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>CalcExpr.NET</PackageId>

--- a/CalcExpr/Context/ExpressionContext.cs
+++ b/CalcExpr/Context/ExpressionContext.cs
@@ -2,21 +2,18 @@
 
 namespace CalcExpr.Context;
 
-public class ExpressionContext
+public class ExpressionContext(Dictionary<string, IExpression> variables)
 {
-    private Dictionary<string, IExpression> _variables;
+    private readonly Dictionary<string, IExpression> _variables = variables ?? [];
 
     public IExpression this[string variable]
     {
-        get => _variables.ContainsKey(variable) ? _variables[variable] : Constant.UNDEFINED;
+        get => _variables.TryGetValue(variable, out IExpression? value) ? value : Constant.UNDEFINED;
         set => _variables[variable] = value;
     }
 
-    public ExpressionContext() : this(new Dictionary<string, IExpression>())
+    public ExpressionContext() : this([])
     { }
-
-    public ExpressionContext(Dictionary<string, IExpression> variables)
-        => _variables = variables ?? new Dictionary<string, IExpression>();
 
     public bool SetVariable(string variable, IExpression expression)
     {

--- a/CalcExpr/Exceptions/ArgumentValueException.cs
+++ b/CalcExpr/Exceptions/ArgumentValueException.cs
@@ -1,11 +1,9 @@
 ﻿namespace CalcExpr.Exceptions;
 
-public class ArgumentValueException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ArgumentValueException"/> class using the specified invalid value.
-    /// </summary>
-    /// <param name="x">The value that is invalid.</param>
-    public ArgumentValueException(double x) : base($"The value '{x}' is not a valid argument value for this operation.")
-    { }
-}
+/// <summary>
+/// Initializes a new instance of the <see cref="ArgumentValueException"/> class using the specified invalid value.
+/// </summary>
+/// <param name="x">The value that is invalid.</param>
+public class ArgumentValueException(double x)
+    : Exception($"The value '{x}' is not a valid argument value for this operation.")
+{ }

--- a/CalcExpr/Exceptions/InvalidAssignmentException.cs
+++ b/CalcExpr/Exceptions/InvalidAssignmentException.cs
@@ -2,14 +2,11 @@
 
 namespace CalcExpr.Exceptions;
 
-public class InvalidAssignmentException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="InvalidAssignmentException"/> class using the specified invalid
-    /// expression.
-    /// </summary>
-    /// <param name="expression">The invalide expression.</param>
-    public InvalidAssignmentException(IExpression expression)
-        : base($"The expression '{expression}' is not a valid assignment expression.")
-    { }
-}
+/// <summary>
+/// Initializes a new instance of the <see cref="InvalidAssignmentException"/> class using the specified invalid
+/// expression.
+/// </summary>
+/// <param name="expression">The invalide expression.</param>
+public class InvalidAssignmentException(IExpression expression)
+    : Exception($"The expression '{expression}' is not a valid assignment expression.")
+{ }

--- a/CalcExpr/Exceptions/NonRegexRuleException.cs
+++ b/CalcExpr/Exceptions/NonRegexRuleException.cs
@@ -1,13 +1,10 @@
 ﻿namespace CalcExpr.Exceptions;
 
-public class NonRegexRuleException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NonRegexRuleException"/> class.
-    /// </summary>
-    /// <param name="name">The name of the invalid <see cref="Rule"/> being referenced.</param>
-    /// <param name="type">The type of the invalid <see cref="Rule"/> being referenced.</param>
-    public NonRegexRuleException(string name, Type type)
-        : base($"The referenced rule '{name}' is of type '{type}' and not a derivative of RegexRule.")
-    { }
-}
+/// <summary>
+/// Initializes a new instance of the <see cref="NonRegexRuleException"/> class.
+/// </summary>
+/// <param name="name">The name of the invalid <see cref="Rule"/> being referenced.</param>
+/// <param name="type">The type of the invalid <see cref="Rule"/> being referenced.</param>
+public class NonRegexRuleException(string name, Type type)
+    : Exception($"The referenced rule '{name}' is of type '{type}' and not a derivative of RegexRule.")
+{ }

--- a/CalcExpr/Exceptions/UnbalancedParenthesesException.cs
+++ b/CalcExpr/Exceptions/UnbalancedParenthesesException.cs
@@ -1,13 +1,10 @@
 ﻿namespace CalcExpr.Exceptions;
 
-public class UnbalancedParenthesesException : Exception
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UnbalancedParenthesesException"/> class using the specified 
-    /// unbalanced expression.
-    /// </summary>
-    /// <param name="expression">The expression with unbalanced parentheses.</param>
-    public UnbalancedParenthesesException(string expression)
-        : base($"The expression '{expression}' contains unbalanced parentheses.")
-    { }
-}
+/// <summary>
+/// Initializes a new instance of the <see cref="UnbalancedParenthesesException"/> class using the specified 
+/// unbalanced expression.
+/// </summary>
+/// <param name="expression">The expression with unbalanced parentheses.</param>
+public class UnbalancedParenthesesException(string expression)
+    : Exception($"The expression '{expression}' contains unbalanced parentheses.")
+{ }

--- a/CalcExpr/Expressions/BinaryOperator.cs
+++ b/CalcExpr/Expressions/BinaryOperator.cs
@@ -3,7 +3,13 @@ using CalcExpr.Exceptions;
 
 namespace CalcExpr.Expressions;
 
-public class BinaryOperator : IExpression
+/// <summary>
+/// Initializes a new instance of the <see cref="BinaryOperator"/> class.
+/// </summary>
+/// <param name="op">The identifier for the operator.</param>
+/// <param name="left">The <see cref="IExpression"/> left operand for this operator.</param>
+/// <param name="right">The <see cref="IExpression"/> right operand for this operator.</param>
+public class BinaryOperator(string op, IExpression left, IExpression right) : IExpression
 {
     private static readonly Dictionary<string, Func<IExpression, IExpression, ExpressionContext, IExpression>> _operators
         = new Dictionary<string, Func<IExpression, IExpression, ExpressionContext, IExpression>>
@@ -41,22 +47,9 @@ public class BinaryOperator : IExpression
             ? Constant.UNDEFINED
             : _operators[Identifier](a, b, vars);
 
-    public readonly string Identifier;
-    public readonly IExpression Left;
-    public readonly IExpression Right;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BinaryOperator"/> class.
-    /// </summary>
-    /// <param name="op">The identifier for the operator.</param>
-    /// <param name="left">The <see cref="IExpression"/> left operand for this operator.</param>
-    /// <param name="right">The <see cref="IExpression"/> right operand for this operator.</param>
-    public BinaryOperator(string op, IExpression left, IExpression right)
-    {
-        Identifier = op;
-        Left = left;
-        Right = right;
-    }
+    public readonly string Identifier = op;
+    public readonly IExpression Left = left;
+    public readonly IExpression Right = right;
 
     public IExpression Clone()
         => new BinaryOperator(Identifier, Left.Clone(), Right.Clone());
@@ -131,14 +124,15 @@ public class BinaryOperator : IExpression
         IExpression a_eval = a.Evaluate(variables);
         IExpression b_eval = b.Evaluate(variables);
 
-        if (a_eval is Number && b_eval is Number)
-            return new Number(((Number)a_eval).Value * ((Number)b_eval).Value).Evaluate();
+        if (a_eval is Number num_a && b_eval is Number num_b)
+            return new Number(num_a.Value * num_b.Value).Evaluate();
         else if ((a_eval is Number a_num && a_num.Value != 0 && Constant.INFINITY.Equals(b_eval)) ||
             (b_eval is Number b_num && b_num.Value != 0 && Constant.INFINITY.Equals(a_eval)) ||
             (Constant.INFINITY.Equals(a_eval) && Constant.INFINITY.Equals(b_eval)) ||
             (Constant.NEGATIVE_INFINITY.Equals(a_eval) && Constant.NEGATIVE_INFINITY.Equals(b_eval)))
             return Constant.INFINITY;
-        else if ((Constant.NEGATIVE_INFINITY.Equals(a_eval) && (b_eval is Number || Constant.INFINITY.Equals(b_eval))) ||
+        else if ((Constant.NEGATIVE_INFINITY.Equals(a_eval) && (b_eval is Number ||
+                Constant.INFINITY.Equals(b_eval))) ||
             (Constant.NEGATIVE_INFINITY.Equals(b_eval) && (a_eval is Number || Constant.INFINITY.Equals(a_eval))))
             return new UnaryOperator("-", true, Constant.INFINITY);
 

--- a/CalcExpr/Expressions/Constant.cs
+++ b/CalcExpr/Expressions/Constant.cs
@@ -2,7 +2,11 @@
 
 namespace CalcExpr.Expressions;
 
-public class Constant : IExpression
+/// <summary>
+/// Initializes a new instance of the the <see cref="Constant"/> class.
+/// </summary>
+/// <param name="identifier">The identifier <see cref="string"/> for this <see cref="Constant"/>.</param>
+public class Constant(string identifier) : IExpression
 {
     private static readonly Dictionary<string, IExpression> _values = new Dictionary<string, IExpression>()
     {
@@ -47,14 +51,7 @@ public class Constant : IExpression
     public static Constant NEGATIVE_INFINITY
         => new Constant("-∞");
 
-    public readonly string Identifier;
-
-    /// <summary>
-    /// Initializes a new instance of the the <see cref="Constant"/> class.
-    /// </summary>
-    /// <param name="identifier">The identifier <see cref="string"/> for this <see cref="Constant"/>.</param>
-    public Constant(string identifier)
-        => Identifier = identifier;
+    public readonly string Identifier = identifier;
 
     public IExpression Clone()
         => new Constant(Identifier);

--- a/CalcExpr/Expressions/Number.cs
+++ b/CalcExpr/Expressions/Number.cs
@@ -2,16 +2,13 @@
 
 namespace CalcExpr.Expressions;
 
-public class Number : IExpression
+/// <summary>
+/// Initializes a new instance of the the <see cref="Number"/> class.
+/// </summary>
+/// <param name="value">The numeric value.</param>
+public class Number(double value) : IExpression
 {
-    public double Value { get; private set; }
-
-    /// <summary>
-    /// Initializes a new instance of the the <see cref="Number"/> class.
-    /// </summary>
-    /// <param name="value">The numeric value.</param>
-    public Number(double value)
-        => Value = value;
+    public double Value { get; private set; } = value;
 
     public IExpression Evaluate()
         => Evaluate(new ExpressionContext());

--- a/CalcExpr/Expressions/Parentheses.cs
+++ b/CalcExpr/Expressions/Parentheses.cs
@@ -2,16 +2,13 @@
 
 namespace CalcExpr.Expressions;
 
-public class Parentheses : IExpression
+/// <summary>
+/// Initializes a new instance of the <see cref="Parentheses"/> class.
+/// </summary>
+/// <param name="inside">The <see cref="IExpression"/> inside of this <see cref="Parentheses"/>.</param>
+public class Parentheses(IExpression inside) : IExpression
 {
-    public readonly IExpression Inside;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Parentheses"/> class.
-    /// </summary>
-    /// <param name="inside">The <see cref="IExpression"/> inside of this <see cref="Parentheses"/>.</param>
-    public Parentheses(IExpression inside)
-        => Inside = inside;
+    public readonly IExpression Inside = inside;
 
     public IExpression Clone()
         => new Parentheses(Inside.Clone());

--- a/CalcExpr/Expressions/UnaryOperator.cs
+++ b/CalcExpr/Expressions/UnaryOperator.cs
@@ -2,7 +2,15 @@
 
 namespace CalcExpr.Expressions;
 
-public class UnaryOperator : IExpression
+/// <summary>
+/// Initializes a new instance of the the <see cref="UnaryOperator"/> class.
+/// </summary>
+/// <param name="op">The identifier for the operator.</param>
+/// <param name="is_prefix">
+/// <see langword="true"/> if the operator is a prefix and <see langword="false"/> if the operator is a postfix.
+/// </param>
+/// <param name="expression">The <see cref="IExpression"/> operand for this operator.</param>
+public class UnaryOperator(string op, bool is_prefix, IExpression expression) : IExpression
 {
     private static readonly Dictionary<string, Func<IExpression, ExpressionContext, IExpression>> _prefixes
         = new Dictionary<string, Func<IExpression, ExpressionContext, IExpression>>
@@ -29,24 +37,9 @@ public class UnaryOperator : IExpression
     private Func<IExpression, ExpressionContext, IExpression> _operation
         => IsPrefix ? _prefixes[Identifier] : _postfixes[Identifier];
 
-    public readonly string Identifier;
-    public readonly bool IsPrefix;
-    public readonly IExpression Inside;
-
-    /// <summary>
-    /// Initializes a new instance of the the <see cref="UnaryOperator"/> class.
-    /// </summary>
-    /// <param name="op">The identifier for the operator.</param>
-    /// <param name="is_prefix">
-    /// <see langword="true"/> if the operator is a prefix and <see langword="false"/> if the operator is a postfix.
-    /// </param>
-    /// <param name="expression">The <see cref="IExpression"/> operand for this operator.</param>
-    public UnaryOperator(string op, bool is_prefix, IExpression expression)
-    {
-        Identifier = op;
-        IsPrefix = is_prefix;
-        Inside = expression;
-    }
+    public readonly string Identifier = op;
+    public readonly bool IsPrefix = is_prefix;
+    public readonly IExpression Inside = expression;
 
     public IExpression Clone()
         => new UnaryOperator(Identifier, IsPrefix, Inside.Clone());
@@ -309,7 +302,7 @@ public class UnaryOperator : IExpression
 
     private static int[] GetNPrimes(int length)
     {
-        List<int> primes = new List<int>() { 2, 3 };
+        List<int> primes = [2, 3];
 
         if (length < 2)
             return primes.ToArray()[..length];
@@ -330,7 +323,7 @@ public class UnaryOperator : IExpression
             i += 2;
         }
 
-        return primes.ToArray();
+        return [.. primes];
     }
 
     private static IExpression PreDecrement(IExpression x, ExpressionContext variables)

--- a/CalcExpr/Expressions/Variable.cs
+++ b/CalcExpr/Expressions/Variable.cs
@@ -2,16 +2,13 @@
 
 namespace CalcExpr.Expressions;
 
-public class Variable : IExpression
+/// <summary>
+/// Initializes a new instance of the the <see cref="Variable"/> class.
+/// </summary>
+/// <param name="name">The name of the <see cref="Variable"/> for reference.</param>
+public class Variable(string name) : IExpression
 {
-    public readonly string Name;
-
-    /// <summary>
-    /// Initializes a new instance of the the <see cref="Variable"/> class.
-    /// </summary>
-    /// <param name="name">The name of the <see cref="Variable"/> for reference.</param>
-    public Variable(string name)
-        => Name = name;
+    public readonly string Name = name;
 
     public IExpression Clone()
         => new Variable(Name);

--- a/CalcExpr/Parsing/Rules/NestedRegexRule.cs
+++ b/CalcExpr/Parsing/Rules/NestedRegexRule.cs
@@ -4,7 +4,19 @@ using System.Text.RegularExpressions;
 
 namespace CalcExpr.Parsing.Rules;
 
-public class NestedRegexRule : RegexRule
+/// <summary>
+/// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
+/// </summary>
+/// <param name="name">The name of the <see cref="NestedRegexRule"/>.</param>
+/// <param name="regex">The regex <see cref="string"/> to match an expression <see cref="string"/> to.</param>
+/// <param name="options">
+/// The options for the regular expression along with additional options finding a match.
+/// </param>
+/// <param name="parse">
+/// The function to use to parse a <see cref="string"/> into an <see cref="IExpression"/>.
+/// </param>
+public class NestedRegexRule(string name, string regex, RegexRuleOptions options,
+    Func<string, Token, Parser, IExpression> parse) : RegexRule(name, regex, options, parse)
 {
     /// <summary>
     /// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
@@ -20,25 +32,9 @@ public class NestedRegexRule : RegexRule
         : this(name, regex, (RegexRuleOptions)options, parse)
     { }
 
-    /// <summary>
-    /// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
-    /// </summary>
-    /// <param name="name">The name of the <see cref="NestedRegexRule"/>.</param>
-    /// <param name="regex">The regex <see cref="string"/> to match an expression <see cref="string"/> to.</param>
-    /// <param name="options">
-    /// The options for the regular expression along with additional options finding a match.
-    /// </param>
-    /// <param name="parse">
-    /// The function to use to parse a <see cref="string"/> into an <see cref="IExpression"/>.
-    /// </param>
-    public NestedRegexRule(string name, string regex, RegexRuleOptions options,
-        Func<string, Token, Parser, IExpression> parse)
-        : base(name, regex, options, parse)
-    { }
-
     public override Token? Match(string input, IEnumerable<Rule> rules)
     {
-        Dictionary<string, string> preprocessed_rules = new Dictionary<string, string>();
+        Dictionary<string, string> preprocessed_rules = [];
         string regex = ReplaceRules(RegularExpression, rules, Options, ref preprocessed_rules);
 
         return FindMatch(input, regex, Options);
@@ -49,7 +45,7 @@ public class NestedRegexRule : RegexRule
     {
         List<Match> matches = Regex.Matches(regular_expression, @"(?<=(^|[^\\](\\\\)*){)\w+(?=})").Distinct().ToList();
 
-        if (matches.Any())
+        if (matches.Count == 0)
         {
             string regex = regular_expression;
             Dictionary<string, int> rule_names = rules.Select((r, i) => new KeyValuePair<string, int>(r.Name, i))
@@ -59,24 +55,24 @@ public class NestedRegexRule : RegexRule
             {
                 string sub_regex;
 
-                if (preprocessed_rules.ContainsKey(match.Value))
+                if (preprocessed_rules.TryGetValue(match.Value, out string? value))
                 {
-                    sub_regex = preprocessed_rules[match.Value];
+                    sub_regex = value;
                 }
-                else if (rule_names.ContainsKey(match.Value))
+                else if (rule_names.TryGetValue(match.Value, out int idx))
                 {
-                    if (rules.ElementAt(rule_names[match.Value]) is NestedRegexRule nrr)
+                    if (rules.ElementAt(idx) is NestedRegexRule nrr)
                     {
                         sub_regex = ReplaceRules(nrr.RegularExpression, rules, options, ref preprocessed_rules);
                         preprocessed_rules.Add(match.Value, sub_regex);
                     }
-                    else if (rules.ElementAt(rule_names[match.Value]) is RegexRule rr)
+                    else if (rules.ElementAt(idx) is RegexRule rr)
                     {
                         sub_regex = rr.RegularExpression;
                     }
                     else
                     {
-                        throw new NonRegexRuleException(match.Value, rules.ElementAt(rule_names[match.Value]).GetType());
+                        throw new NonRegexRuleException(match.Value, rules.ElementAt(idx).GetType());
                     }
 
                     rule_names.Remove(match.Value);

--- a/CalcExpr/Parsing/Rules/ReferenceRegexRule.cs
+++ b/CalcExpr/Parsing/Rules/ReferenceRegexRule.cs
@@ -4,18 +4,15 @@ using System.Text.RegularExpressions;
 
 namespace CalcExpr.Parsing.Rules;
 
+/// <summary>
+/// A rule to be used as a reference for a <see cref="NestedRegexRule"/>.
+/// </summary>
+/// <param name="name">The name of the <see cref="ReferenceRegexRule"/>.</param>
+/// <param name="regex">The regex <see cref="string"/> to match an expression <see cref="string"/> to.</param>
 [ReferenceRule]
-public class ReferenceRegexRule : NestedRegexRule
+public class ReferenceRegexRule(string name, string regex)
+    : NestedRegexRule(name, regex, RegexOptions.None, (_, _, _) => Constant.UNDEFINED)
 {
-    /// <summary>
-    /// A rule to be used as a reference for a <see cref="NestedRegexRule"/>.
-    /// </summary>
-    /// <param name="name">The name of the <see cref="ReferenceRegexRule"/>.</param>
-    /// <param name="regex">The regex <see cref="string"/> to match an expression <see cref="string"/> to.</param>
-    public ReferenceRegexRule(string name, string regex)
-        : base(name, regex, RegexOptions.None, (_, _, _) => Constant.UNDEFINED)
-    { }
-
     public override bool Equals(object? obj)
         => obj is not null && obj is RegexRule a && RegularExpression == a.RegularExpression;
 

--- a/CalcExpr/Parsing/Rules/RegexRule.cs
+++ b/CalcExpr/Parsing/Rules/RegexRule.cs
@@ -3,10 +3,22 @@ using System.Text.RegularExpressions;
 
 namespace CalcExpr.Parsing.Rules;
 
-public class RegexRule : Rule
+/// <summary>
+/// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
+/// </summary>
+/// <param name="name">The name of the <see cref="RegexRule"/>.</param>
+/// <param name="regex">The regex <see cref="string"/> to match an expression <see cref="string"/> to.</param>
+/// <param name="options">
+/// The options for the regular expression along with additional options finding a match.
+/// </param>
+/// <param name="parse">
+/// The function to use to parse a <see cref="string"/> into an <see cref="IExpression"/>.
+/// </param>
+public class RegexRule(string name, string regex, RegexRuleOptions options,
+    Func<string, Token, Parser, IExpression> parse) : Rule(name, parse, null!)
 {
-    public readonly string RegularExpression;
-    public readonly RegexRuleOptions Options;
+    public readonly string RegularExpression = regex;
+    public readonly RegexRuleOptions Options = options;
     
     public RegexOptions RegularOptions
         => (RegexOptions)((int)Options & 0x0000FFFF);
@@ -24,25 +36,6 @@ public class RegexRule : Rule
         Func<string, Token, Parser, IExpression> parse)
         : this(name, regex, (RegexRuleOptions)options, parse)
     { }
-
-    /// <summary>
-    /// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
-    /// </summary>
-    /// <param name="name">The name of the <see cref="RegexRule"/>.</param>
-    /// <param name="regex">The regex <see cref="string"/> to match an expression <see cref="string"/> to.</param>
-    /// <param name="options">
-    /// The options for the regular expression along with additional options finding a match.
-    /// </param>
-    /// <param name="parse">
-    /// The function to use to parse a <see cref="string"/> into an <see cref="IExpression"/>.
-    /// </param>
-    public RegexRule(string name, string regex, RegexRuleOptions options,
-        Func<string, Token, Parser, IExpression> parse)
-        : base(name, parse, null!)
-    {
-        RegularExpression = regex;
-        Options = options;
-    }
 
     public override Token? Match(string input, IEnumerable<Rule> rules)
         => FindMatch(input, RegularExpression, Options);

--- a/CalcExpr/Parsing/Rules/Rule.cs
+++ b/CalcExpr/Parsing/Rules/Rule.cs
@@ -2,26 +2,19 @@
 
 namespace CalcExpr.Parsing.Rules;
 
-public class Rule
+/// <summary>
+/// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
+/// </summary>
+/// <param name="name">The name of the <see cref="Rule"/>.</param>
+/// <param name="parse">The function to use to parse a input <see cref="string"/>.</param>
+/// <param name="match">The function to use to find a match in the input <see cref="string"/>.</param>
+public class Rule(string name, Func<string, Token, Parser, IExpression> parse,
+    Func<string, IEnumerable<Rule>, Token?> match)
 {
-    private readonly Func<string, IEnumerable<Rule>, Token?> _match;
+    private readonly Func<string, IEnumerable<Rule>, Token?> _match = match;
 
-    public readonly string Name;
-    public readonly Func<string, Token, Parser, IExpression> Parse;
-
-    /// <summary>
-    /// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
-    /// </summary>
-    /// <param name="name">The name of the <see cref="Rule"/>.</param>
-    /// <param name="parse">The function to use to parse a input <see cref="string"/>.</param>
-    /// <param name="match">The function to use to find a match in the input <see cref="string"/>.</param>
-    public Rule(string name, Func<string, Token, Parser, IExpression> parse,
-        Func<string, IEnumerable<Rule>, Token?> match)
-    {
-        Name = name;
-        Parse = parse;
-        _match = match;
-    }
+    public readonly string Name = name;
+    public readonly Func<string, Token, Parser, IExpression> Parse = parse;
 
     /// <summary>
     /// The function that gets used to find a match in an input <see cref="string"/>. This function might get overriden

--- a/CalcExpr/Parsing/Token.cs
+++ b/CalcExpr/Parsing/Token.cs
@@ -2,25 +2,19 @@
 
 namespace CalcExpr.Parsing;
 
-public readonly struct Token
+/// <summary>
+/// Creates and initializes a new <see cref="Token"/> with the specified <paramref name="value"/>, 
+/// <paramref name="index"/>, and <paramref name="index"/>.
+/// </summary>
+/// <param name="value">The <see cref="string"/> contained within the <see cref="Token"/>.</param>
+/// <param name="index">The starting index within the containing <see cref="string"/>.</param>
+public readonly struct Token(string value, int index)
 {
-    public readonly string Value;
-    public readonly int Index;
+    public readonly string Value = value;
+    public readonly int Index = index;
 
     public int Length
         => Value.Length;
-
-    /// <summary>
-    /// Creates and initializes a new <see cref="Token"/> with the specified <paramref name="value"/>, 
-    /// <paramref name="index"/>, and <paramref name="index"/>.
-    /// </summary>
-    /// <param name="value">The <see cref="string"/> contained within the <see cref="Token"/>.</param>
-    /// <param name="index">The starting index within the containing <see cref="string"/>.</param>
-    public Token(string value, int index)
-    {
-        Value = value;
-        Index = index;
-    }
 
     public static implicit operator Token(Match match)
         => new Token(match.Value, match.Index);

--- a/TestCalcExpr/TestCalcExpr.csproj
+++ b/TestCalcExpr/TestCalcExpr.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Upgraded the CalcExpr and TestCalcExpr projects from .NET 6 to .NET 8 along with fixing each message in the error list to update to recommended syntax for .NET 8, like primary constructors and collection expressions.