### PR TITLE
48 Combine Match and Parse Functions

### DIFF
--- a/CalcExpr/Parsing/ContextFreeUtils.cs
+++ b/CalcExpr/Parsing/ContextFreeUtils.cs
@@ -110,6 +110,32 @@ public static class ContextFreeUtils
     }
 
     /// <summary>
+    /// Tokenizes the input string by replacing all bracketed expressions with a token.
+    /// </summary>
+    /// <param name="input">The input string to tokenize.</param>
+    /// <param name="tokens">The tokens that were created from the input string.</param>
+    /// <param name="tokenized">The tokenized string.</param>
+    /// <param name="brackets">Type of brackets to tokenize.</param>
+    /// <returns>
+    /// <see langword="true"/> if the input string was tokenized successfully, <see langword="false"/> otherwise.
+    /// </returns>"
+    public static bool TryTokenizeInput(this string input, out Token[] tokens, out string? tokenized,
+        Brackets brackets = Brackets.All)
+    {
+        try
+        {
+            tokenized = input.TokenizeInput(out tokens, brackets);
+            return true;
+        }
+        catch
+        {
+            tokens = [];
+            tokenized = null;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Checks if the input string has balanced brackets.
     /// </summary>
     /// <param name="input">The input string to check.</param>

--- a/CalcExpr/Parsing/MatchFunctions.cs
+++ b/CalcExpr/Parsing/MatchFunctions.cs
@@ -1,0 +1,99 @@
+﻿using CalcExpr.Parsing.Rules;
+using System.Text.RegularExpressions;
+
+namespace CalcExpr.Parsing;
+
+internal static class MatchFunctions
+{
+    internal static Token? MatchParentheses(string input, IEnumerable<Rule> rules)
+    {
+        input = input.Trim();
+
+        if (String.IsNullOrWhiteSpace(input))
+            return null;
+
+        if (input[0] == '(' && input[^1] == ')')
+        {
+            int depth = 0;
+
+            for (int i = 1; i < input.Length - 1; i++)
+            {
+                char current = input[i];
+
+                if (current == '(')
+                {
+                    depth++;
+                }
+                else if (current == ')')
+                {
+                    if (depth == 0)
+                        return null;
+
+                    depth--;
+                }
+            }
+
+            if (depth == 0)
+                return new Token(input[1..^1], 1);
+        }
+
+        return null;
+    }
+
+    internal static Token? MatchCollection(string input, IEnumerable<Rule> rules)
+    {
+        Match match = Regex.Match(input, @"(?<=^\s*)[\[\{].*?[\]\}](?=\s*$)");
+
+        if (match.Success && match.Value[^1] - match.Value[0] == 2)
+        {
+            try
+            {
+                if (ContextFreeUtils.CheckBalancedBrackets(match.Value[1..^1], Brackets.Square | Brackets.Curly))
+                    return match;
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
+        return null;
+    }
+
+    internal static Token? MatchFunctionCall(string input, IEnumerable<Rule> rules)
+    {
+        input = input.Trim();
+
+        if (String.IsNullOrWhiteSpace(input))
+            return null;
+
+        Match function_name = Regex.Match(input, @"^([A-Za-zΑ-Ωα-ω]+(_[A-Za-zΑ-Ωα-ω0-9]+)*)");
+
+        if (function_name.Success)
+        {
+            Token? parentheses = MatchParentheses(input[function_name.Length..], rules);
+
+            if (parentheses is not null)
+                return new Token(
+                    input[..(function_name.Length + parentheses.Value.Index + parentheses.Value.Length + 1)],
+                    0);
+        }
+
+        return null;
+    }
+
+    internal static Token? MatchIndexer(string input, IEnumerable<Rule> rules)
+    {
+        ContextFreeUtils.TokenizeInput(input, out Token[] tokens, Brackets.Square);
+
+        if (tokens.Length > 0)
+        {
+            Token match = tokens.Last();
+
+            if (!match[1..^1].Contains(','))
+                return match;
+        }
+
+        return null;
+    }
+}

--- a/CalcExpr/Parsing/MatchFunctions.cs
+++ b/CalcExpr/Parsing/MatchFunctions.cs
@@ -5,7 +5,7 @@ namespace CalcExpr.Parsing;
 
 internal static class MatchFunctions
 {
-    internal static Token? MatchParentheses(string input, IEnumerable<Rule> rules)
+    internal static Token? MatchParentheses(string input, IEnumerable<IRule> _)
     {
         input = input.Trim();
 
@@ -40,7 +40,7 @@ internal static class MatchFunctions
         return null;
     }
 
-    internal static Token? MatchCollection(string input, IEnumerable<Rule> rules)
+    internal static Token? MatchCollection(string input, IEnumerable<IRule> _)
     {
         Match match = Regex.Match(input, @"(?<=^\s*)[\[\{].*?[\]\}](?=\s*$)");
 
@@ -60,7 +60,7 @@ internal static class MatchFunctions
         return null;
     }
 
-    internal static Token? MatchFunctionCall(string input, IEnumerable<Rule> rules)
+    internal static Token? MatchFunctionCall(string input, IEnumerable<IRule> rules)
     {
         input = input.Trim();
 
@@ -82,7 +82,7 @@ internal static class MatchFunctions
         return null;
     }
 
-    internal static Token? MatchIndexer(string input, IEnumerable<Rule> rules)
+    internal static Token? MatchIndexer(string input, IEnumerable<IRule> _)
     {
         ContextFreeUtils.TokenizeInput(input, out Token[] tokens, Brackets.Square);
 

--- a/CalcExpr/Parsing/MatchFunctions.cs
+++ b/CalcExpr/Parsing/MatchFunctions.cs
@@ -5,41 +5,6 @@ namespace CalcExpr.Parsing;
 
 internal static class MatchFunctions
 {
-    internal static Token? MatchParentheses(string input, IEnumerable<IRule> _)
-    {
-        input = input.Trim();
-
-        if (String.IsNullOrWhiteSpace(input))
-            return null;
-
-        if (input[0] == '(' && input[^1] == ')')
-        {
-            int depth = 0;
-
-            for (int i = 1; i < input.Length - 1; i++)
-            {
-                char current = input[i];
-
-                if (current == '(')
-                {
-                    depth++;
-                }
-                else if (current == ')')
-                {
-                    if (depth == 0)
-                        return null;
-
-                    depth--;
-                }
-            }
-
-            if (depth == 0)
-                return new Token(input[1..^1], 1);
-        }
-
-        return null;
-    }
-
     internal static Token? MatchCollection(string input, IEnumerable<IRule> _)
     {
         Match match = Regex.Match(input, @"(?<=^\s*)[\[\{].*?[\]\}](?=\s*$)");
@@ -77,6 +42,41 @@ internal static class MatchFunctions
                 return new Token(
                     input[..(function_name.Length + parentheses.Value.Index + parentheses.Value.Length + 1)],
                     0);
+        }
+
+        return null;
+    }
+
+    internal static Token? MatchParentheses(string input, IEnumerable<IRule> _)
+    {
+        input = input.Trim();
+
+        if (String.IsNullOrWhiteSpace(input))
+            return null;
+
+        if (input[0] == '(' && input[^1] == ')')
+        {
+            int depth = 0;
+
+            for (int i = 1; i < input.Length - 1; i++)
+            {
+                char current = input[i];
+
+                if (current == '(')
+                {
+                    depth++;
+                }
+                else if (current == ')')
+                {
+                    if (depth == 0)
+                        return null;
+
+                    depth--;
+                }
+            }
+
+            if (depth == 0)
+                return new Token(input[1..^1], 1);
         }
 
         return null;

--- a/CalcExpr/Parsing/ParseFunctions.cs
+++ b/CalcExpr/Parsing/ParseFunctions.cs
@@ -1,11 +1,30 @@
 ﻿using CalcExpr.Expressions;
+using CalcExpr.Expressions.Collections;
 using System.Text.RegularExpressions;
-using static CalcExpr.Parsing.MatchFunctions;
 
 namespace CalcExpr.Parsing;
 
 internal static class ParseFunctions
 {
+    internal static IExpression? ParseCollection(string input, Parser parser)
+    {
+        Match match = Regex.Match(input, @"(?<=^\s*)[\[\{].*?[\]\}](?=\s*$)");
+
+        if (match.Success && match.Value[^1] - match.Value[0] == 2 &&
+            ContextFreeUtils.TryTokenizeInput(match.Value[1..^1], out Token[] tokens, out string? tokenized,
+            Brackets.Square | Brackets.Curly))
+        {
+            IEnumerable<IExpression> enumerable = tokenized!.Split(',')
+                .Select(e => parser.Parse(Regex.Replace(e, @"(?<!(^|[^\\])\\(\\\\)*)\[\d+\]", m => m.Value[1..^1])));
+
+            return match.Value[0] == '['
+                ? new Vector(enumerable)
+                : new Set(enumerable);
+        }
+
+        return null;
+    }
+
     internal static IExpression? ParseFunctionCall(string input, Parser parser)
     {
         input = input.Trim();
@@ -19,7 +38,7 @@ internal static class ParseFunctions
         {
             string args = input[function_name.Length..].TrimStart();
 
-            if (args[0] == '(' && args[^1] == ')')
+            if (!String.IsNullOrWhiteSpace(args) && args[0] == '(' && args[^1] == ')')
             {
                 string tokenized_args = args[1..^1].TokenizeInput(out Token[] tokens);
                 string[] split_args = tokenized_args

--- a/CalcExpr/Parsing/ParseFunctions.cs
+++ b/CalcExpr/Parsing/ParseFunctions.cs
@@ -1,0 +1,38 @@
+﻿using CalcExpr.Expressions;
+using System.Text.RegularExpressions;
+using static CalcExpr.Parsing.MatchFunctions;
+
+namespace CalcExpr.Parsing;
+
+internal static class ParseFunctions
+{
+    internal static IExpression? ParseFunctionCall(string input, Parser parser)
+    {
+        input = input.Trim();
+
+        if (String.IsNullOrWhiteSpace(input))
+            return null;
+
+        Match function_name = Regex.Match(input, @"^([A-Za-zΑ-Ωα-ω]+(_[A-Za-zΑ-Ωα-ω0-9]+)*)");
+
+        if (function_name.Success)
+        {
+            string args = input[function_name.Length..].TrimStart();
+
+            if (args[0] == '(' && args[^1] == ')')
+            {
+                string tokenized_args = args[1..^1].TokenizeInput(out Token[] tokens);
+                string[] split_args = tokenized_args
+                    .Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(arg => !arg.Contains('[')
+                        ? arg
+                        : Regex.Replace(arg, @"\[\d+\]", match => tokens[Convert.ToInt32(match.Value[1..^1])]))
+                    .ToArray();
+
+                return new FunctionCall(function_name.Value, split_args.Select(parser.Parse));
+            }
+        }
+
+        return null;        
+    }
+}

--- a/CalcExpr/Parsing/ParseMatchFunctions.cs
+++ b/CalcExpr/Parsing/ParseMatchFunctions.cs
@@ -99,14 +99,14 @@ internal static class ParseMatchFunctions
         => new BinaryOperator(match.Value, parser.Parse(input[..match.Index]),
             parser.Parse(input[(match.Index + match.Length)..]));
 
-    internal static Indexer ParseMatchIndexer(string input, Token match, Parser parser)
-        => new Indexer(parser.Parse(input[..match.Index]), parser.Parse(match[1..^1]));
-
     internal static UnaryOperator ParseMatchPrefix(string input, Token match, Parser parser)
         => new UnaryOperator(match.Value, true, parser.Parse(input[(match.Index + match.Length)..]));
 
     internal static UnaryOperator ParseMatchPostfix(string input, Token match, Parser parser)
         => new UnaryOperator(match.Value, false, parser.Parse(input[..match.Index]));
+
+    internal static Indexer ParseMatchIndexer(string input, Token match, Parser parser)
+        => new Indexer(parser.Parse(input[..match.Index]), parser.Parse(match[1..^1]));
 
     internal static Constant ParseMatchConstant(string _, Token match, Parser parser)
         => new Constant(match.Value);

--- a/CalcExpr/Parsing/ParseMatchFunctions.cs
+++ b/CalcExpr/Parsing/ParseMatchFunctions.cs
@@ -1,0 +1,119 @@
+﻿using CalcExpr.Attributes;
+using CalcExpr.Expressions;
+using CalcExpr.Expressions.Collections;
+using CalcExpr.Expressions.Components;
+using CalcExpr.Parsing.Rules;
+using System.Text.RegularExpressions;
+using System.Reflection;
+
+namespace CalcExpr.Parsing;
+
+internal static class ParseMatchFunctions
+{
+    internal static IEnumerableExpression ParseMatchCollection(string input, Token token, Parser parser)
+    {
+        string tokenized = ContextFreeUtils.TokenizeInput(token.Value[1..^1], out Token[] tokens,
+            Brackets.Square | Brackets.Curly);
+        IEnumerable<IExpression> enumerable = tokenized.Split(',')
+            .Select(e => parser.Parse(Regex.Replace(e, @"(?<!(^|[^\\])\\(\\\\)*)\[\d+\]", m => m.Value[1..^1])));
+
+        return token.Value[0] == '['
+            ? new Vector(enumerable)
+            : new Set(enumerable);
+    }
+
+    internal static FunctionCall ParseMatchFunctionCall(string input, Token token, Parser parser)
+    {
+        Match function_name = Regex.Match(input, @"(?<=^\s*)([A-Za-zΑ-Ωα-ω]+(_[A-Za-zΑ-Ωα-ω0-9]+)*)");
+        string tokenized_args = token.Value[(function_name.Length + 1)..^1].TokenizeInput(out Token[] tokens);
+
+        string[] args = tokenized_args
+            .Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(arg => !arg.Contains('[')
+                ? arg
+                : Regex.Replace(arg, @"\[\d+\]", match => tokens[Convert.ToInt32(match.Value[1..^1])]))
+            .ToArray();
+
+        return new FunctionCall(function_name.Value, args.Select(arg => parser.Parse(arg)));
+    }
+
+    internal static LambdaFunction ParseMatchLambdaFunction(string input, Token token, Parser parser)
+    {
+        string parameters_string = Regex.Match(token.Value.Trim(), @"(?<=^\(?).*?(?=\)?\s*=>)").Value.TrimStart('(');
+        string tokenized_parameters_string = parameters_string.TokenizeInput(out Token[] attribute_tokens,
+            Brackets.Square);
+        IEnumerable<Parameter> parameters = tokenized_parameters_string
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(p =>
+            {
+                Match attribute_match = Regex.Match(p, @"(?<=^\s*\[)\d+(?=\])");
+                string? attribute_string = attribute_match.Success
+                    ? attribute_tokens[Convert.ToInt32(attribute_match.Value)].Value[1..^1]
+                    : null;
+                IEnumerable<string> attributes = attribute_string is null
+                    ? Enumerable.Empty<string>()
+                    : Regex.Split(attribute_string, @"(?<!\([^\)]*?),(?![^\(]*?\))");
+
+                return new Parameter(Regex.Match(p,
+                    @$"(?<=\]?\s*){((RegexRule?)parser.GetGrammarRule("Variable"))!.RegularExpression}(?=\s*$)").Value,
+                    attributes);
+            }).ToArray();
+
+        return new LambdaFunction(parameters, parser.Parse(input[(token.Index + token.Length)..]));
+    }
+
+    internal static Parentheses ParseMatchParentheses(string input, Token token, Parser parser)
+        => new Parentheses(parser.Parse(token));
+
+    internal static IExpression ParseMatchWithParentheses(string input, Token _, Parser parser)
+    {
+        string tokenized_input = input.TokenizeInput(out Token[] tokens, Brackets.Parenthesis);
+
+        foreach (Rule rule in parser.Grammar)
+        {
+            if (rule.GetType().GetCustomAttribute<ReferenceRuleAttribute>() is not null)
+                continue;
+
+            Token? match = rule.Match(tokenized_input, parser.Grammar);
+
+            if (match.HasValue)
+            {
+                IExpression? result = rule.Parse(input,
+                    new Token(match.Value, ContextFreeUtils.DetokenizeIndex(match.Value.Index, tokenized_input,
+                        tokens)),
+                    parser);
+
+                if (result is not null)
+                    return result;
+            }
+        }
+
+        throw new Exception($"The input was not in the correct format: '{input}'");
+    }
+
+    internal static AssignmentOperator ParseMatchAssignmentOperator(string input, Token match, Parser parser)
+        => new AssignmentOperator((parser.Parse(input[..match.Index]) as Variable)!,
+            parser.Parse(input[(match.Index + match.Length)..]));
+
+    internal static BinaryOperator ParseMatchBinaryOperator(string input, Token match, Parser parser)
+        => new BinaryOperator(match.Value, parser.Parse(input[..match.Index]),
+            parser.Parse(input[(match.Index + match.Length)..]));
+
+    internal static Indexer ParseMatchIndexer(string input, Token match, Parser parser)
+        => new Indexer(parser.Parse(input[..match.Index]), parser.Parse(match[1..^1]));
+
+    internal static UnaryOperator ParseMatchPrefix(string input, Token match, Parser parser)
+        => new UnaryOperator(match.Value, true, parser.Parse(input[(match.Index + match.Length)..]));
+
+    internal static UnaryOperator ParseMatchPostfix(string input, Token match, Parser parser)
+        => new UnaryOperator(match.Value, false, parser.Parse(input[..match.Index]));
+
+    internal static Constant ParseMatchConstant(string input, Token match, Parser parser)
+        => new Constant(match.Value);
+
+    internal static Variable ParseMatchVariable(string input, Token match, Parser parser)
+        => new Variable(match.Value);
+
+    internal static Number ParseMatchNumber(string input, Token match, Parser parser)
+        => new Number(Convert.ToDouble(match.Value));
+}

--- a/CalcExpr/Parsing/ParseMatchFunctions.cs
+++ b/CalcExpr/Parsing/ParseMatchFunctions.cs
@@ -10,7 +10,7 @@ namespace CalcExpr.Parsing;
 
 internal static class ParseMatchFunctions
 {
-    internal static IEnumerableExpression ParseMatchCollection(string input, Token token, Parser parser)
+    internal static IEnumerableExpression ParseMatchCollection(string _, Token token, Parser parser)
     {
         string tokenized = ContextFreeUtils.TokenizeInput(token.Value[1..^1], out Token[] tokens,
             Brackets.Square | Brackets.Curly);
@@ -62,14 +62,14 @@ internal static class ParseMatchFunctions
         return new LambdaFunction(parameters, parser.Parse(input[(token.Index + token.Length)..]));
     }
 
-    internal static Parentheses ParseMatchParentheses(string input, Token token, Parser parser)
+    internal static Parentheses ParseMatchParentheses(string _, Token token, Parser parser)
         => new Parentheses(parser.Parse(token));
 
     internal static IExpression ParseMatchWithParentheses(string input, Token _, Parser parser)
     {
         string tokenized_input = input.TokenizeInput(out Token[] tokens, Brackets.Parenthesis);
 
-        foreach (Rule rule in parser.Grammar)
+        foreach (IRule rule in parser.Grammar)
         {
             if (rule.GetType().GetCustomAttribute<ReferenceRuleAttribute>() is not null)
                 continue;
@@ -108,12 +108,12 @@ internal static class ParseMatchFunctions
     internal static UnaryOperator ParseMatchPostfix(string input, Token match, Parser parser)
         => new UnaryOperator(match.Value, false, parser.Parse(input[..match.Index]));
 
-    internal static Constant ParseMatchConstant(string input, Token match, Parser parser)
+    internal static Constant ParseMatchConstant(string _, Token match, Parser parser)
         => new Constant(match.Value);
 
-    internal static Variable ParseMatchVariable(string input, Token match, Parser parser)
+    internal static Variable ParseMatchVariable(string _, Token match, Parser parser)
         => new Variable(match.Value);
 
-    internal static Number ParseMatchNumber(string input, Token match, Parser parser)
+    internal static Number ParseMatchNumber(string _, Token match, Parser parser)
         => new Number(Convert.ToDouble(match.Value));
 }

--- a/CalcExpr/Parsing/Parser.cs
+++ b/CalcExpr/Parsing/Parser.cs
@@ -39,7 +39,7 @@ public class Parser
             new ReferenceRegexRule("TokenizedParameter",
                 @"((\\?\[{TokenizedAttribute}(,{TokenizedAttribute})*\\?\])?{Variable})",
                 RegexRuleOptions.PadReferences),
-            new Rule("Collection", ParseMatchCollection, MatchCollection),
+            new Rule("Collection", ParseCollection, MatchCollection, ParseMatchCollection),
             new Rule("FunctionCall", ParseFunctionCall, MatchFunctionCall, ParseMatchFunctionCall),
             new NestedRegexRule("LambdaFunction", @"({Parameter}|\(\s*(({Parameter},)*{Parameter})?\))\s*=>",
                 RegexRuleOptions.Left | RegexRuleOptions.PadReferences | RegexRuleOptions.Trim,
@@ -113,17 +113,12 @@ public class Parser
             if (rule.GetType().GetCustomAttribute<ReferenceRuleAttribute>() is not null)
                 continue;
 
-            Token? match = rule.Match(input, Grammar);
+            IExpression? expression = rule.Parse(input, this);
 
-            if (match.HasValue)
+            if (expression is not null)
             {
-                IExpression? expression = rule.Parse(input, match.Value, this);
-
-                if (expression is not null)
-                {
-                    AddCache(input, expression);
-                    return expression;
-                }
+                AddCache(input, expression);
+                return expression;
             }
         }
 

--- a/CalcExpr/Parsing/Parser.cs
+++ b/CalcExpr/Parsing/Parser.cs
@@ -116,10 +116,13 @@ public class Parser
 
             if (match.HasValue)
             {
-                IExpression expression = rule.Parse.Invoke(input, match.Value, this);
+                IExpression? expression = rule.Parse(input, match.Value, this);
 
-                AddCache(input, expression);
-                return expression;
+                if (expression is not null)
+                {
+                    AddCache(input, expression);
+                    return expression;
+                }
             }
         }
 
@@ -477,10 +480,15 @@ public class Parser
             Token? match = rule.Match(tokenized_input, parser.Grammar);
 
             if (match.HasValue)
-                return rule.Parse.Invoke(input,
+            {
+                IExpression? result = rule.Parse(input,
                     new Token(match.Value, ContextFreeUtils.DetokenizeIndex(match.Value.Index, tokenized_input,
                         tokens)),
                     parser);
+
+                if (result is not null)
+                    return result;
+            }
         }
 
         throw new Exception($"The input was not in the correct format: '{input}'");

--- a/CalcExpr/Parsing/Parser.cs
+++ b/CalcExpr/Parsing/Parser.cs
@@ -11,10 +11,10 @@ namespace CalcExpr.Parsing;
 
 public class Parser
 {
-    private readonly List<Rule> _grammar = [];
+    private readonly List<IRule> _grammar = [];
     private readonly Dictionary<string, IExpression> _cache = [];
 
-    public Rule[] Grammar
+    public IRule[] Grammar
         => _grammar.ToArray();
 
     public string[] Cache
@@ -86,7 +86,7 @@ public class Parser
     /// The specified <see cref="IEnumerable{Rule}"/> to be used as the grammar of the <see cref="Parser"/>.
     /// </param>
     /// <param name="build_rules">Whether or not grammar rules should be prebuilt.</param>
-    public Parser(IEnumerable<Rule> grammar, bool build_rules = true)
+    public Parser(IEnumerable<IRule> grammar, bool build_rules = true)
     {
         _grammar = grammar.ToList();
 
@@ -108,7 +108,7 @@ public class Parser
         if (ContainsCache(input))
             return _cache[CleanExpressionString(input)];
 
-        foreach (Rule rule in _grammar)
+        foreach (IRule rule in _grammar)
         {
             if (rule.GetType().GetCustomAttribute<ReferenceRuleAttribute>() is not null)
                 continue;
@@ -194,16 +194,16 @@ public class Parser
     }
 
     /// <summary>
-    /// Add <see cref="Rule"/> to the grammar of the <see cref="Parser"/>.
+    /// Add <see cref="IRule"/> to the grammar of the <see cref="Parser"/>.
     /// </summary>
-    /// <param name="rule">The <see cref="Rule"/> to be added to the grammar.</param>
-    /// <param name="index">The index to put the <see cref="Rule"/> in the grammar.</param>
+    /// <param name="rule">The <see cref="IRule"/> to be added to the grammar.</param>
+    /// <param name="index">The index to put the <see cref="IRule"/> in the grammar.</param>
     /// <param name="build_rules">Whether or not grammar rules should be rebuilt.</param>
     /// <returns>
-    /// <see langword="true"/> if the <see cref="Rule"/> was successfully added to the grammar; otherwise, 
+    /// <see langword="true"/> if the <see cref="IRule"/> was successfully added to the grammar; otherwise, 
     /// <see langword="false"/>.
     /// </returns>
-    public bool AddGrammarRule(Rule rule, int index = -1, bool build_rules = true)
+    public bool AddGrammarRule(IRule rule, int index = -1, bool build_rules = true)
     {
         if (index < 0)
             index += _grammar.Count + 1;
@@ -229,12 +229,12 @@ public class Parser
     }
 
     /// <summary>
-    /// Removes the <see cref="Rule"/> with the specified name from the grammar of the <see cref="Parser"/>.
+    /// Removes the <see cref="IRule"/> with the specified name from the grammar of the <see cref="Parser"/>.
     /// </summary>
-    /// <param name="name">The name of the <see cref="Rule"/> to be removed.</param>
+    /// <param name="name">The name of the <see cref="IRule"/> to be removed.</param>
     /// <param name="build_rules">Whether or not grammar rules should be rebuilt.</param>
     /// <returns>
-    /// <see langword="true"/> if the <see cref="Rule"/> was successfully removed; otherwise, <see langword="false"/>.
+    /// <see langword="true"/> if the <see cref="IRule"/> was successfully removed; otherwise, <see langword="false"/>.
     /// </returns>
     public bool RemoveGrammarRule(string name, bool build_rules = true)
     {
@@ -246,12 +246,12 @@ public class Parser
     }
 
     /// <summary>
-    /// Removes the <see cref="Rule"/> at the specified index from the grammar of the <see cref="Parser"/>.
+    /// Removes the <see cref="IRule"/> at the specified index from the grammar of the <see cref="Parser"/>.
     /// </summary>
-    /// <param name="index">The index for the <see cref="Rule"/> to be removed.</param>
+    /// <param name="index">The index for the <see cref="IRule"/> to be removed.</param>
     /// <param name="build_rules">Whether or not grammar rules should be rebuilt.</param>
     /// <returns>
-    /// <see langword="true"/> if the <see cref="Rule"/> was successfully removed; otherwise, <see langword="false"/>.
+    /// <see langword="true"/> if the <see cref="IRule"/> was successfully removed; otherwise, <see langword="false"/>.
     /// </returns>
     public bool RemoveGrammarRuleAt(int index, bool build_rules = true)
     {
@@ -273,13 +273,13 @@ public class Parser
     /// <summary>
     /// Determines whether a rule with the specified name is in the grammar of the <see cref="Parser"/>.
     /// </summary>
-    /// <param name="name">The name of the <see cref="Rule"/> to find.</param>
+    /// <param name="name">The name of the <see cref="IRule"/> to find.</param>
     /// <returns>
-    /// <see langword="true"/> if the <see cref="Rule"/> was successfully found; otherwise, <see langword="false"/>.
+    /// <see langword="true"/> if the <see cref="IRule"/> was successfully found; otherwise, <see langword="false"/>.
     /// </returns>
     public bool GrammarContains(string name)
     {
-        foreach (Rule rule in _grammar)
+        foreach (IRule rule in _grammar)
             if (rule.Name == name)
                 return true;
 
@@ -287,11 +287,11 @@ public class Parser
     }
 
     /// <summary>
-    /// Gets a <see cref="Rule"/> from the grammar based on the specified name.
+    /// Gets a <see cref="IRule"/> from the grammar based on the specified name.
     /// </summary>
     /// <param name="name">The name of the grammar rule.</param>
-    /// <returns>The <see cref="Rule"/> in the grammar with the name <paramref name="name"/>.</returns>
-    public Rule? GetGrammarRule(string name)
+    /// <returns>The <see cref="IRule"/> in the grammar with the name <paramref name="name"/>.</returns>
+    public IRule? GetGrammarRule(string name)
     {
         int idx = 0;
 
@@ -302,11 +302,11 @@ public class Parser
     }
 
     /// <summary>
-    /// Gets a <see cref="Rule"/> from the grammar based on the specified index.
+    /// Gets a <see cref="IRule"/> from the grammar based on the specified index.
     /// </summary>
     /// <param name="index">The index of the grammar rule.</param>
-    /// <returns>The <see cref="Rule"/> in the grammar at the index of <paramref name="index"/>.</returns>
-    public Rule? GetGrammarRule(int index)
+    /// <returns>The <see cref="IRule"/> in the grammar at the index of <paramref name="index"/>.</returns>
+    public IRule? GetGrammarRule(int index)
         => index >= 0 && index < _grammar.Count ? _grammar[index] : null;
 
     /// <summary>
@@ -315,9 +315,9 @@ public class Parser
     public void RebuildGrammarRules()
         => BuildGrammarRules(_grammar);
 
-    private static void BuildGrammarRules(IEnumerable<Rule> rules)
+    private static void BuildGrammarRules(IEnumerable<IRule> rules)
     {
-        foreach (Rule rule in rules)
+        foreach (IRule rule in rules)
             if (rule is NestedRegexRule regex_rule)
                 regex_rule.Build(rules);
     }

--- a/CalcExpr/Parsing/Rules/NestedRegexRule.cs
+++ b/CalcExpr/Parsing/Rules/NestedRegexRule.cs
@@ -43,7 +43,7 @@ public class NestedRegexRule(string name, string regex_template, RegexRuleOption
         : this(name, regex_template, (RegexRuleOptions)options, parse)
     { }
 
-    public override Token? Match(string input, IEnumerable<Rule> rules)
+    public override Token? Match(string input, IEnumerable<IRule> rules)
     {
         if (RegularExpression is null)
             Build(rules);
@@ -51,12 +51,12 @@ public class NestedRegexRule(string name, string regex_template, RegexRuleOption
         return FindMatch(input, RegularExpression!, Options);
     }
 
-    public void Build(IEnumerable<Rule> rules)
+    public void Build(IEnumerable<IRule> rules)
     {
         _regex = ReplaceRules(RegularExpressionTemplate, rules, Options);
     }
 
-    private static string ReplaceRules(string regular_expression, IEnumerable<Rule> rules, RegexRuleOptions options)
+    private static string ReplaceRules(string regular_expression, IEnumerable<IRule> rules, RegexRuleOptions options)
     {
         List<string> matches = Regex.Matches(regular_expression, @"(?<=(^|[^\\](\\\\)*){)\w+(?=})")
             .Select(m => m.Value)

--- a/CalcExpr/Parsing/Rules/Rule.cs
+++ b/CalcExpr/Parsing/Rules/Rule.cs
@@ -5,44 +5,34 @@ namespace CalcExpr.Parsing.Rules;
 /// <summary>
 /// A rule to be used to parse a <see cref="string"/> into an <see cref="IExpression"/>.
 /// </summary>
-/// <param name="name">The name of the <see cref="Rule"/>.</param>
+/// <param name="name">The name of the <see cref="IRule"/>.</param>
 /// <param name="parse">The function to use to parse a input <see cref="string"/>.</param>
 /// <param name="match">The function to use to find a match in the input <see cref="string"/>.</param>
-public class Rule(string name, Func<string, Parser, IExpression?> parse, Func<string, IEnumerable<Rule>, Token?> match,
-    Func<string, Token, Parser, IExpression>? parse_match = null)
+public class Rule(string name, Func<string, Parser, IExpression?> parse, Func<string, IEnumerable<IRule>, Token?> match,
+    Func<string, Token, Parser, IExpression>? parse_match = null) : IRule
 {
-    public readonly Func<string, Parser, IExpression?> _parse = parse;
-    private readonly Func<string, IEnumerable<Rule>, Token?> _match = match;
+    private readonly Func<string, Parser, IExpression?> _parse = parse;
+    private readonly Func<string, IEnumerable<IRule>, Token?> _match = match;
     private readonly Func<string, Token, Parser, IExpression>? _parse_match = parse_match;
 
-    public readonly string Name = name;
+    public string Name { get; } = name;
 
     public Rule(string name, Func<string, Token, Parser, IExpression> parse,
-        Func<string, IEnumerable<Rule>, Token?> match) : this(name, MatchAndParse(parse, match), match, parse)
+        Func<string, IEnumerable<IRule>, Token?> match) : this(name, MatchAndParse(parse, match), match, parse)
     {
     }
 
-    /// <summary>
-    /// The function that gets used to find a match in an input <see cref="string"/>. This function might get overriden
-    /// in derrived classes.
-    /// </summary>
-    /// <param name="input">The input <see cref="string"/> to find the match in.</param>
-    /// <param name="rules">Other rules from the calling <see cref="Parser"/>.</param>
-    /// <returns>
-    /// A new <see cref="Token"/> containing the value of the matching <see cref="string"/> and the index of where it
-    /// was found; <see langword="null"/> if no match was found.
-    /// </returns>
-    public virtual Token? Match(string input, IEnumerable<Rule> rules)
+    public Token? Match(string input, IEnumerable<IRule> rules)
         => _match(input, rules);
 
-    public virtual IExpression? Parse(string input, Parser parser)
+    public IExpression? Parse(string input, Parser parser)
         => _parse(input, parser);
 
-    public virtual IExpression? Parse(string input, Token match, Parser parser)
+    public IExpression? Parse(string input, Token match, Parser parser)
         => _parse_match is null ? Parse(input, parser) : _parse_match(input, match, parser);
 
     private static Func<string, Parser, IExpression?> MatchAndParse(Func<string, Token, Parser, IExpression> parse,
-        Func<string, IEnumerable<Rule>, Token?> match)
+        Func<string, IEnumerable<IRule>, Token?> match)
     {
         return (i, p) => {
             Token? token = match(i, p.Grammar);
@@ -65,4 +55,42 @@ public class Rule(string name, Func<string, Parser, IExpression?> parse, Func<st
 
     public static bool operator !=(Rule a, Rule b)
         => !a.Equals(b);
+}
+
+public interface IRule
+{
+    public string Name { get; }
+
+    /// <summary>
+    /// The function that gets used to find a match in an input <see cref="string"/>. This function might get overriden
+    /// in derrived classes.
+    /// </summary>
+    /// <param name="input">The input <see cref="string"/> to find the match in.</param>
+    /// <param name="rules">Other rules from the calling <see cref="Parser"/>.</param>
+    /// <returns>
+    /// A new <see cref="Token"/> containing the value of the matching <see cref="string"/> and the index of where it
+    /// was found; <see langword="null"/> if no match was found.
+    /// </returns>
+    Token? Match(string input, IEnumerable<IRule> rules);
+
+    /// <summary>
+    /// Tries to parse the input <see cref="string"/> into an <see cref="IExpression"/>.
+    /// </summary>
+    /// <param name="input">The input <see cref="string"/> to parse.</param>
+    /// <param name="parser">The <see cref="Parser"/> to use to parse any sub-expressions.</param>
+    /// <returns>
+    /// The parsed <see cref="IExpression"/>; <see langword="null"/> if the input could not be parsed.
+    /// </returns>
+    IExpression? Parse(string input, Parser parser);
+
+    /// <summary>
+    /// Tries to parse the input <see cref="string"/> into an <see cref="IExpression"/> using the given token.
+    /// </summary>
+    /// <param name="input">The input <see cref="string"/> to parse.</param>
+    /// <param name="token">The matching <see cref="Token"/> to use to parse the input.</param>
+    /// <param name="parser">The <see cref="Parser"/> to use to parse any sub-expressions.</param>
+    /// <returns>
+    /// The parsed <see cref="IExpression"/>; <see langword="null"/> if the input could not be parsed.
+    /// </returns>
+    IExpression? Parse(string input, Token token, Parser parser);
 }

--- a/TestCalcExpr/Parsing/TestParser.cs
+++ b/TestCalcExpr/Parsing/TestParser.cs
@@ -54,7 +54,7 @@ public class TestParser
 
         for (int i = 0; i < default_rules.Length; i++)
         {
-            Rule rule = parser.Grammar[i];
+            IRule rule = parser.Grammar[i];
 
             Assert.AreEqual(default_rules[i].Name, rule.Name);
 
@@ -67,10 +67,10 @@ public class TestParser
             Assert.AreEqual(rule, parser.GetGrammarRule(i));
         }
 
-        parser = new Parser(new Rule[] { CUSTOM_RULE });
+        parser = new Parser([CUSTOM_RULE]);
 
         Assert.IsTrue(parser.Grammar.Length == 1);
-        Assert.IsTrue(parser.Grammar[0] == CUSTOM_RULE);
+        Assert.IsTrue((RegexRule)parser.Grammar[0] == CUSTOM_RULE);
     }
 
     /// <summary>
@@ -142,9 +142,9 @@ public class TestParser
         Assert.IsFalse(parser.Grammar.Contains(CUSTOM_RULE));
         Assert.IsFalse(parser.Grammar.Contains(tau));
         Assert.IsTrue(parser.AddGrammarRule(CUSTOM_RULE, 0));
-        Assert.IsTrue(parser.Grammar[0] == CUSTOM_RULE);
+        Assert.IsTrue((RegexRule)parser.Grammar[0] == CUSTOM_RULE);
         Assert.IsTrue(parser.AddGrammarRule(tau, -1));
-        Assert.IsTrue(parser.Grammar.Last() == tau);
+        Assert.IsTrue((RegexRule)parser.Grammar.Last() == tau);
         Assert.IsTrue(parser.GrammarContains(tau.Name));
         Assert.IsTrue(parser.RemoveGrammarRule(CUSTOM_RULE.Name));
         Assert.IsFalse(parser.GrammarContains(CUSTOM_RULE.Name));


### PR DESCRIPTION
Added the option to have a combined match and parse function for each grammar rule in order to reduce repeating code and calculations, such as those that use bracket tokenizing