### PR TITLE
39 Primitive Type Parameters

### DIFF
--- a/CalcExpr/BuiltInFunctions/CollectionFunctions.cs
+++ b/CalcExpr/BuiltInFunctions/CollectionFunctions.cs
@@ -44,17 +44,12 @@ public static class CollectionFunctions
     }
 
     [BuiltInFunction("range")]
-    public static IExpression Range(Number start, Number count, Number step)
+    public static IExpression Range(int start, int count, int step)
     {
-        if (start.Value % 1 != 0 || count.Value % 1 != 0 || step.Value % 1 != 0 || count.Value < 0)
+        if (start % 1 != 0 || count % 1 != 0 || step % 1 != 0 || count < 0)
             return Constant.UNDEFINED;
 
-        int start_value = (int)start.Value;
-        int count_value = (int)count.Value;
-        int step_value = (int)step.Value;
-
-        return Vector.ConvertIEnumerable(Enumerable.Range(0, count_value)
-            .Select(i => (Number)(start_value + i * step_value)));
+        return Vector.ConvertIEnumerable(Enumerable.Range(0, count).Select(i => (Number)(start + i * step)));
     }
 
     [BuiltInFunction("random")]
@@ -136,48 +131,43 @@ public static class CollectionFunctions
     }
 
     [BuiltInFunction("insert")]
-    public static IExpression Insert(IEnumerableExpression collection, IExpression element, Number index)
+    public static IExpression Insert(IEnumerableExpression collection, IExpression element, int index)
     {
-        if (index.Value % 1 != 0 || index.Value < -collection.Count() || index.Value > collection.Count())
+        if (index % 1 != 0 || index < -collection.Count() || index > collection.Count())
             return Constant.UNDEFINED;
 
         return (IExpression?)collection.GetType().GetMethod("ConvertIEnumerable")?
-            .Invoke(null, [collection.Insert((int)index.Value, element)])
+            .Invoke(null, [collection.Insert(index, element)])
             ?? Constant.UNDEFINED;
     }
 
     [BuiltInFunction("remove")]
-    public static IExpression Remove(IEnumerableExpression collection, Number index)
+    public static IExpression Remove(IEnumerableExpression collection, int index)
     {
-        if (!collection.Any() || index.Value % 1 != 0 || index.Value < -collection.Count() ||
-            index.Value >= collection.Count())
+        if (!collection.Any() || index % 1 != 0 || index < -collection.Count() || index >= collection.Count())
             return Constant.UNDEFINED;
 
         return (IExpression?)collection.GetType().GetMethod("ConvertIEnumerable")?
-            .Invoke(null, [collection.Remove((int)index.Value)])
+            .Invoke(null, [collection.Remove(index)])
             ?? Constant.UNDEFINED;
     }
 
     [BuiltInFunction("any", "some")]
-    public static IExpression Any(IEnumerableExpression collection, IFunction condition, ExpressionContext context)
+    public static bool Any(IEnumerableExpression collection, IFunction condition, ExpressionContext context)
     {
         return ((IEnumerableExpression)collection.Evaluate(context))
-            .Any(x => Constant.TRUE.Equals(new AsBooleanAttribute().Preprocess(condition.Invoke([x], context))))
-            ? Constant.TRUE
-            : Constant.FALSE;
+            .Any(x => Constant.TRUE.Equals(new AsBooleanAttribute().Preprocess(condition.Invoke([x], context))));
     }
 
     [BuiltInFunction("all")]
-    public static IExpression All(IEnumerableExpression collection, IFunction condition, ExpressionContext context)
+    public static bool All(IEnumerableExpression collection, IFunction condition, ExpressionContext context)
     {
         return ((IEnumerableExpression)collection.Evaluate(context))
-            .All(x => Constant.TRUE.Equals(new AsBooleanAttribute().Preprocess(condition.Invoke([x], context))))
-            ? Constant.TRUE
-            : Constant.FALSE;
+            .All(x => Constant.TRUE.Equals(new AsBooleanAttribute().Preprocess(condition.Invoke([x], context))));
     }
 
     [BuiltInFunction("find")]
-    public static IExpression Find(IEnumerableExpression collection, IExpression item)
+    public static int? Find(IEnumerableExpression collection, IExpression item)
     {
         try
         {
@@ -185,11 +175,11 @@ public static class CollectionFunctions
                 .First(element => element.x.Equals(item))
                 .i;
 
-            return (Number)index;
+            return index;
         }
         catch (InvalidOperationException)
         {
-            return Constant.UNDEFINED;
+            return null;
         }
     }
 
@@ -213,8 +203,7 @@ public static class CollectionFunctions
     [BuiltInFunction("reverse")]
     public static IExpression Reverse(IEnumerableExpression collection)
     {
-        return (IExpression?)collection.GetType().GetMethod("ConvertIEnumerable")?
-            .Invoke(null, [collection.Reverse()])
+        return (IExpression?)collection.GetType().GetMethod("ConvertIEnumerable")?.Invoke(null, [collection.Reverse()])
             ?? Constant.UNDEFINED;
     }
 

--- a/CalcExpr/BuiltInFunctions/LogicalFunctions.cs
+++ b/CalcExpr/BuiltInFunctions/LogicalFunctions.cs
@@ -10,91 +10,75 @@ public static class LogicalFunctions
 {
     [BuiltInFunction("and")]
     [Elementwise]
-    public static IExpression And([AsBoolean][NotUndefined] IExpression a, [AsBoolean][NotUndefined] IExpression b)
-        => Constant.FALSE.Equals(a) || Constant.FALSE.Equals(b)
-            ? Constant.FALSE
-            : Constant.TRUE;
+    public static bool And(bool a, bool b)
+        => a && b;
 
     [BuiltInFunction("or")]
     [Elementwise]
-    public static IExpression Or([AsBoolean][NotUndefined] IExpression a, [AsBoolean][NotUndefined] IExpression b)
-        => Constant.TRUE.Equals(a) || Constant.TRUE.Equals(b)
-            ? Constant.TRUE
-            : Constant.FALSE;
+    public static bool Or(bool a, bool b)
+        => a || b;
 
     [BuiltInFunction("xor")]
     [Elementwise]
-    public static IExpression Xor([AsBoolean][NotUndefined] IExpression a, [AsBoolean][NotUndefined] IExpression b)
-    {
-        bool a_bool = Constant.TRUE.Equals(a);
-        bool b_bool = Constant.TRUE.Equals(b);
-
-        return (a_bool || b_bool) && !(a_bool && b_bool)
-            ? Constant.TRUE
-            : Constant.FALSE;
-    }
+    public static bool Xor(bool a, bool b)
+        => (a || b) && !(a && b);
 
     [BuiltInFunction("not")]
     [Elementwise]
-    public static IExpression Not([AsBoolean][NotUndefined] IExpression x)
-        => Constant.TRUE.Equals(x) ? Constant.FALSE : Constant.TRUE;
+    public static bool Not(bool x)
+        => !x;
 
     [BuiltInFunction("bool")]
     [Elementwise]
-    public static IExpression Bool([AsBoolean][NotUndefined] IExpression x)
+    public static bool Bool(bool x)
         => x;
 
     [BuiltInFunction("if")]
     [Elementwise]
-    public static IExpression If([AsBoolean][NotUndefined] IExpression condition, IExpression is_true,
-        IExpression is_false)
-        => Constant.TRUE.Equals(condition) ? is_true : is_false;
+    public static IExpression If(bool condition, IExpression is_true, IExpression is_false)
+        => condition ? is_true : is_false;
 
     [BuiltInFunction("is_na")]
-    public static IExpression IsNa(IExpression x, ExpressionContext _)
-        => Constant.UNDEFINED.Equals(x) ? Constant.TRUE : Constant.FALSE;
+    public static bool IsNa(IExpression x, ExpressionContext _)
+        => Constant.UNDEFINED.Equals(x);
 
     [BuiltInFunction("is_num", "is_number")]
-    public static IExpression IsNum(IExpression x, ExpressionContext _)
-        => x is Number ? Constant.TRUE : Constant.FALSE;
+    public static bool IsNum(IExpression x, ExpressionContext _)
+        => x is Number;
 
     [BuiltInFunction("is_int", "is_integer")]
-    public static IExpression IsInt(IExpression x, ExpressionContext _)
-        => x is Number num && num.Value % 1 == 0
-            ? Constant.TRUE
-            : Constant.FALSE;
+    public static bool IsInt(IExpression x, ExpressionContext _)
+        => x is Number num && num.Value % 1 == 0;
 
     [BuiltInFunction("is_logical")]
-    public static IExpression IsLogical(IExpression x, ExpressionContext _)
-        => Constant.TRUE.Equals(x) || Constant.FALSE.Equals(x)
-            ? Constant.TRUE
-            : Constant.FALSE;
+    public static bool IsLogical(IExpression x, ExpressionContext _)
+        => Constant.TRUE.Equals(x) || Constant.FALSE.Equals(x);
 
     [BuiltInFunction("is_even")]
-    public static IExpression IsEven(Number x)
-        => x.Value % 2 == 0
-            ? Constant.TRUE
-            : Constant.FALSE;
+    public static bool? IsEven(double x)
+        => Double.IsFinite(x)
+            ? x % 2 == 0
+            : null;
 
     [BuiltInFunction("is_odd")]
-    public static IExpression IsOdd(Number x)
-        => Math.Abs(x.Value % 2) == 1
-            ? Constant.TRUE
-            : Constant.FALSE;
+    public static bool? IsOdd(double x)
+        => Double.IsFinite(x)
+            ? Math.Abs(x) % 2 == 1
+            : null;
 
     [BuiltInFunction("is_positive")]
-    public static IExpression IsPositive(IExpression x)
-        => (x is Number num && num.Value > 0) || Constant.INFINITY.Equals(x)
-            ? Constant.TRUE
-            : !Constant.UNDEFINED.Equals(x)
-                ? Constant.FALSE
-                : Constant.UNDEFINED;
+    public static bool? IsPositive(double x)
+        => x > 0
+            ? true
+            : !Double.IsNaN(x)
+                ? false
+                : null;
 
     [BuiltInFunction("is_negative")]
-    public static IExpression IsNegative(IExpression x, ExpressionContext _)
-        => (x is Number num && num.Value < 0) || Constant.NEGATIVE_INFINITY.Equals(x)
-            ? Constant.TRUE
-            : !Constant.UNDEFINED.Equals(x)
-                ? Constant.FALSE
-                : Constant.UNDEFINED;
+    public static bool? IsNegative(double x, ExpressionContext _)
+        => x < 0
+            ? true
+            : !Double.IsNaN(x)
+                ? false
+                : null;
 }

--- a/CalcExpr/BuiltInFunctions/StatisticalFunctions.cs
+++ b/CalcExpr/BuiltInFunctions/StatisticalFunctions.cs
@@ -8,11 +8,11 @@ namespace CalcExpr.BuiltInFunctions;
 public static class StatisticalFunctions
 {
     [BuiltInFunction("count", "length", "len")]
-    public static IExpression Count(IExpression expressions)
+    public static int Count(IExpression expressions)
     {
         return expressions is IEnumerableExpression enum_expr
-            ? (Number)enum_expr.Count()
-            : (Number)1;
+            ? enum_expr.Count()
+            : 1;
     }
 
     [BuiltInFunction("max", "maximum")]
@@ -79,29 +79,26 @@ public static class StatisticalFunctions
                 .Where(kvp => kvp.Value == max)
                 .Select(kvp => kvp.Key);
 
-            // TODO: Change to Set.
             return modes.Count() == 1
                 ? modes.Single()
-                : new Vector(modes);
+                : new Set(modes);
         }
 
         return expressions;
     }
 
     [BuiltInFunction("percentile")]
-    public static IExpression Percentile([AreNumbers] IExpression expressions, [IsNumber] IExpression p)
+    public static IExpression Percentile([AreNumbers] IExpression expressions, double p)
     {
         if (expressions is IEnumerableExpression enum_expr)
         {
-            double p_val = ((Number)p).Value;
-
-            if (!enum_expr.Any() || p_val < 0 || p_val > 1)
+            if (!enum_expr.Any() || p < 0 || p > 1)
                 return Constant.UNDEFINED;
             else if (enum_expr.Count() == 1)
                 return enum_expr.Single();
 
             IEnumerable<Number> values = enum_expr.Select(x => (Number)x).OrderBy(x => x.Value);
-            double i = (values.Count() - 1) * p_val;
+            double i = (values.Count() - 1) * p;
             int prev_i = (int)Math.Floor(i);
 
             if (prev_i == values.Count() - 1)
@@ -119,9 +116,9 @@ public static class StatisticalFunctions
     }
 
     [BuiltInFunction("quartile")]
-    public static IExpression Quartile([AreNumbers] IExpression expressions, [IsNumber] IExpression q)
+    public static IExpression Quartile([AreNumbers] IExpression expressions, [Range(0, 4)] double q)
     {
-        return Percentile(expressions, (Number)(((Number)q).Value / 4));
+        return Percentile(expressions, q / 4);
     }
 
     [BuiltInFunction("stdev", "stdevs")]

--- a/CalcExpr/BuiltInFunctions/TrigonometricFunctions.cs
+++ b/CalcExpr/BuiltInFunctions/TrigonometricFunctions.cs
@@ -1,5 +1,4 @@
 ﻿using CalcExpr.Attributes;
-using CalcExpr.Expressions;
 using CalcExpr.FunctionAttributes.ConditionalAttributes;
 
 namespace CalcExpr.BuiltInFunctions;
@@ -8,216 +7,208 @@ public static class TrigonometricFunctions
 {
     [BuiltInFunction("sin")]
     [Elementwise]
-    public static IExpression Sin(Number x)
-        => new Number(Math.Sin(((Number)x).Value));
+    public static double Sin(double x)
+        => Math.Sin(x);
 
     [BuiltInFunction("cos")]
     [Elementwise]
-    public static IExpression Cos(Number x)
-        => new Number(Math.Cos(((Number)x).Value));
+    public static double Cos(double x)
+        => Math.Cos(x);
 
     [BuiltInFunction("tan")]
     [Elementwise]
-    public static IExpression Tan(Number x)
-    {
-        Number num = (Number)x;
-        
-        return (num.Value / Math.PI - 0.5) % 1 == 0
-            ? Constant.UNDEFINED
-            : new Number(Math.Tan(num.Value)).Evaluate();
+    public static double Tan(double x)
+    {        
+        return (x / Math.PI - 0.5) % 1 == 0
+            ? Double.NaN
+            : Math.Tan(x);
     }
 
     [BuiltInFunction("asin", "arcsin", "arsin")]
     [Elementwise]
-    public static IExpression Asin(Number x)
-        => new Number(Math.Asin(((Number)x).Value)).Evaluate();
+    public static double Asin(double x)
+        => Math.Asin(x);
 
     [BuiltInFunction("acos", "arccos", "arcos")]
     [Elementwise]
-    public static IExpression Acos(Number x)
-        => new Number(Math.Acos(((Number)x).Value)).Evaluate();
+    public static double Acos(double x)
+        => Math.Acos(x);
 
     [BuiltInFunction("atan", "arctan", "artan")]
     [Elementwise]
-    public static IExpression Atan([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(Math.Atan(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x)
-                ? new Number(Math.PI / 2)
-                : Constant.NEGATIVE_INFINITY.Equals(x)
-                    ? new Number(-Math.PI / 2)
-                    : Constant.UNDEFINED;
+    public static double Atan(double x)
+        => Double.IsFinite(x)
+            ? Math.Atan(x)
+            : Double.IsPositiveInfinity(x)
+                ? Math.PI / 2
+                : Double.IsNegativeInfinity(x)
+                    ? -Math.PI / 2
+                    : Double.NaN;
 
     [BuiltInFunction("csc")]
     [Elementwise]
-    public static IExpression Csc(Number x)
+    public static double Csc(double x)
     {
-        Number num = (Number)x;
-
-        return num.Value / Math.PI % 1 == 0
-            ? Constant.UNDEFINED
-            : new Number(1 / Math.Sin(num.Value)).Evaluate();
+        return x / Math.PI % 1 == 0
+            ? Double.NaN
+            : 1 / Math.Sin(x);
     }
 
     [BuiltInFunction("sec")]
     [Elementwise]
-    public static IExpression Sec(Number x)
+    public static double Sec(double x)
     {
-        Number num = (Number)x;
-        
-        return (num.Value / Math.PI - 0.5) % 1 == 0
-            ? Constant.UNDEFINED
-            : new Number(1 / Math.Cos(num.Value)).Evaluate();
+        return (x / Math.PI - 0.5) % 1 == 0
+            ? Double.NaN
+            : 1 / Math.Cos(x);
     }
 
     [BuiltInFunction("cot")]
     [Elementwise]
-    public static IExpression Cot(Number x)
+    public static double Cot(double x)
     {
-        Number num = (Number)x;
-
-        return num.Value / Math.PI % 1 == 0
-            ? Constant.UNDEFINED
-            : new Number(1 / Math.Tan(num.Value)).Evaluate();
+        return x / Math.PI % 1 == 0
+            ? Double.NaN
+            : 1 / Math.Tan(x);
     }
 
     [BuiltInFunction("acsc", "arccsc", "arcsc")]
     [Elementwise]
-    public static IExpression Acsc([NotUndefined][Gap(-1, 1)] IExpression x)
-        => x is Number num
-            ? new Number(Math.Asin(1 / num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? new Number(0)
-                : Constant.UNDEFINED;
+    public static double Acsc([Gap(-1, 1)] double x)
+        => Double.IsFinite(x)
+            ? Math.Asin(1 / x)
+            : Double.IsInfinity(x)
+                ? 0
+                : Double.NaN;
 
     [BuiltInFunction("asec", "arcsec", "arsec")]
     [Elementwise]
-    public static IExpression Asec([NotUndefined][Gap(-1, 1)] IExpression x)
-        => x is Number num
-            ? new Number(Math.Acos(1 / num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? new Number(Math.PI / 2)
-                : Constant.UNDEFINED;
+    public static double Asec([Gap(-1, 1)] double x)
+        => Double.IsFinite(x)
+            ? Math.Acos(1 / x)
+            : Double.IsInfinity(x)
+                ? Math.PI / 2
+                : Double.NaN;
 
     [BuiltInFunction("acot", "arccot", "arcot")]
     [Elementwise]
-    public static IExpression Acot([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(Math.PI / 2 - Math.Atan(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x)
-                ? new Number(0)
-                : Constant.NEGATIVE_INFINITY.Equals(x)
-                    ? new Number(Math.PI)
-                    : Constant.UNDEFINED;
+    public static double Acot(double x)
+        => Double.IsFinite(x)
+            ? Math.PI / 2 - Math.Atan(x)
+            : Double.IsPositiveInfinity(x)
+                ? 0
+                : Double.IsNegativeInfinity(x)
+                    ? Math.PI
+                    : Double.NaN;
 
     [BuiltInFunction("sinh")]
     [Elementwise]
-    public static IExpression Sinh([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(Math.Sinh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
+    public static double Sinh(double x)
+        => Double.IsFinite(x)
+            ? Math.Sinh(x)
+            : Double.IsInfinity(x)
                 ? x
-                : Constant.UNDEFINED;
+                : Double.NaN;
 
     [BuiltInFunction("cosh")]
     [Elementwise]
-    public static IExpression Cosh([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(Math.Cosh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? Constant.INFINITY
-                : Constant.UNDEFINED;
+    public static double Cosh(double x)
+        => Double.IsFinite(x)
+            ? Math.Cosh(x)
+            : Double.IsInfinity(x)
+                ? Double.PositiveInfinity
+                : Double.NaN;
 
     [BuiltInFunction("tanh")]
     [Elementwise]
-    public static IExpression Tanh([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(Math.Tanh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x)
-                ? new Number(1)
-                : Constant.NEGATIVE_INFINITY.Equals(x)
-                    ? new Number(-1)
-                    : Constant.UNDEFINED;
+    public static double Tanh(double x)
+        => Double.IsFinite(x)
+            ? Math.Tanh(x)
+            : Double.IsPositiveInfinity(x)
+                ? 1
+                : Double.IsNegativeInfinity(x)
+                    ? -1
+                    : Double.NaN;
 
     [BuiltInFunction("asinh", "arcsinh", "arsinh")]
     [Elementwise]
-    public static IExpression Asinh([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(Math.Asinh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x)
-                ? Constant.INFINITY
-                : Constant.NEGATIVE_INFINITY.Equals(x)
-                    ? Constant.NEGATIVE_INFINITY
-                    : Constant.UNDEFINED;
+    public static double Asinh(double x)
+        => Double.IsFinite(x)
+            ? Math.Asinh(x)
+            : Double.IsPositiveInfinity(x)
+                ? Double.PositiveInfinity
+                : Double.IsNegativeInfinity(x)
+                    ? Double.NegativeInfinity
+                    : Double.NaN;
 
     [BuiltInFunction("acosh", "arccosh", "arcosh")]
     [Elementwise]
-    public static IExpression Acosh([NotUndefined][Minimum(1)] IExpression x)
-        => x is Number num
-            ? new Number(Math.Acosh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x)
-                ? Constant.INFINITY
-                : Constant.UNDEFINED;
+    public static double Acosh([Minimum(1)] double x)
+        => Double.IsFinite(x)
+            ? Math.Acosh(x)
+            : Double.IsPositiveInfinity(x)
+                ? Double.PositiveInfinity
+                : Double.NaN;
 
     [BuiltInFunction("atanh", "arctanh", "artanh")]
     [Elementwise]
-    public static IExpression Atanh(Number x)
-        => new Number(Math.Atanh(((Number)x).Value)).Evaluate();
+    public static double Atanh(double x)
+        => Math.Atanh(x);
 
     [BuiltInFunction("csch")]
     [Elementwise]
-    public static IExpression Csch([NotUndefined][Gap(0, 0, inclusive: true)] IExpression x)
-        => x is Number num
-            ? new Number(1 / Math.Sinh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? new Number(0)
-                : Constant.UNDEFINED;
+    public static double Csch([Gap(0, 0, inclusive: true)] double x)
+        => Double.IsFinite(x)
+            ? 1 / Math.Sinh(x)
+            : Double.IsInfinity(x)
+                ? 0
+                : Double.NaN;
 
     [BuiltInFunction("sech")]
     [Elementwise]
-    public static IExpression Sech([NotUndefined] IExpression x)
-        => x is Number num
-            ? new Number(1 / Math.Cosh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? new Number(0)
-                : Constant.UNDEFINED;
+    public static double Sech(double x)
+        => Double.IsFinite(x)
+            ? 1 / Math.Cosh(x)
+            : Double.IsInfinity(x)
+                ? 0
+                : Double.NaN;
 
     [BuiltInFunction("coth")]
     [Elementwise]
-    public static IExpression Coth([NotUndefined][Gap(0, 0, inclusive: true)] IExpression x)
-        => x is Number num
-            ? new Number(Math.Cosh(num.Value) / Math.Sinh(num.Value)).Evaluate()
-            : Constant.INFINITY.Equals(x)
-                ? new Number(1)
-                : Constant.NEGATIVE_INFINITY.Equals(x)
-                    ? new Number(-1)
-                    : Constant.UNDEFINED;
+    public static double Coth([Gap(0, 0, inclusive: true)] double x)
+        => Double.IsFinite(x)
+            ? Math.Cosh(x) / Math.Sinh(x)
+            : Double.IsPositiveInfinity(x)
+                ? 1
+                : Double.IsNegativeInfinity(x)
+                    ? -1
+                    : Double.NaN;
 
     [BuiltInFunction("acsch", "arccsch", "arcsch")]
     [Elementwise]
-    public static IExpression Acsch([NotUndefined][Gap(0, 0, inclusive: true)] IExpression x)
-        => x is Number num
-            ? Asinh(new Number(1 / num.Value))
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? new Number(0)
-                : Constant.UNDEFINED;
+    public static double Acsch([Gap(0, 0, inclusive: true)] double x)
+        => Double.IsFinite(x)
+            ? Asinh(1 / x)
+            : Double.IsInfinity(x)
+                ? 0
+                : Double.NaN;
 
     [BuiltInFunction("asech", "arcsech", "arsech")]
     [Elementwise]
-    public static IExpression Asech([IsNumber][Range(0, 1)] IExpression x)
-        => Acosh(new Number(1 / ((Number)x).Value));
+    public static double Asech([Range(0, 1)] double x)
+        => Acosh(1 / x);
 
     [BuiltInFunction("acoth", "arccoth", "arcoth")]
     [Elementwise]
-    public static IExpression Acoth([NotUndefined][Gap(-1, 1)] IExpression x)
-        => x is Number num
-            ? num.Value switch
+    public static double Acoth([Gap(-1, 1)] double x)
+        => Double.IsFinite(x)
+            ? x switch
             {
-                1 => Constant.INFINITY,
-                -1 => Constant.NEGATIVE_INFINITY,
-                _ => Atanh(new Number(1 / num.Value))
+                1 => Double.PositiveInfinity,
+                -1 => Double.NegativeInfinity,
+                _ => Atanh(1 / x)
             }
-            : Constant.INFINITY.Equals(x) || Constant.NEGATIVE_INFINITY.Equals(x)
-                ? new Number(0)
-                : Constant.UNDEFINED;
+            : Double.IsInfinity(x)
+                ? 0
+                : Double.NaN;
 }

--- a/CalcExpr/Context/ExpressionContext.cs
+++ b/CalcExpr/Context/ExpressionContext.cs
@@ -7,6 +7,27 @@ namespace CalcExpr.Context;
 
 public class ExpressionContext
 {
+    internal static readonly Dictionary<Type, List<ITypeConverter>> DEFAULT_CONVERTERS =
+        new Dictionary<Type, List<ITypeConverter>>
+        {
+            { typeof(bool), [new BooleanTypeConverter()] },
+            { typeof(sbyte), [new IntegerTypeConverter<sbyte>()] },
+            { typeof(short), [new IntegerTypeConverter<short>()] },
+            { typeof(int), [new IntegerTypeConverter<int>()] },
+            { typeof(long), [new IntegerTypeConverter<long>()] },
+            { typeof(Int128), [new IntegerTypeConverter<Int128>()] },
+            { typeof(byte), [new IntegerTypeConverter<byte>()] },
+            { typeof(ushort), [new IntegerTypeConverter<ushort>()] },
+            { typeof(uint), [new IntegerTypeConverter<uint>()] },
+            { typeof(ulong), [new IntegerTypeConverter<ulong>()] },
+            { typeof(UInt128), [new IntegerTypeConverter<UInt128>()] },
+            { typeof(Half), [new FloatTypeConverter<Half>()] },
+            { typeof(float), [new FloatTypeConverter<float>()] },
+            { typeof(double), [new FloatTypeConverter<double>()] },
+            { typeof(decimal), [new DecimalTypeConverter()] },
+        };
+    internal static readonly Type[] DEFAULT_TYPES = [.. DEFAULT_CONVERTERS.Keys];
+
     private readonly Dictionary<string, IExpression> _variables;
     private readonly Dictionary<string, IFunction> _functions;
     private readonly Dictionary<Type, List<ITypeConverter>> _type_converters;
@@ -58,24 +79,7 @@ public class ExpressionContext
 
         if (type_converters is null)
         {
-            types = new Dictionary<Type, List<ITypeConverter>>
-            {
-                { typeof(bool), [new BooleanTypeConverter()] },
-                { typeof(sbyte), [new IntegerTypeConverter<sbyte>()] },
-                { typeof(short), [new IntegerTypeConverter<short>()] },
-                { typeof(int), [new IntegerTypeConverter<int>()] },
-                { typeof(long), [new IntegerTypeConverter<long>()] },
-                { typeof(Int128), [new IntegerTypeConverter<Int128>()] },
-                { typeof(byte), [new IntegerTypeConverter<byte>()] },
-                { typeof(ushort), [new IntegerTypeConverter<ushort>()] },
-                { typeof(uint), [new IntegerTypeConverter<uint>()] },
-                { typeof(ulong), [new IntegerTypeConverter<ulong>()] },
-                { typeof(UInt128), [new IntegerTypeConverter<UInt128>()] },
-                { typeof(Half), [new FloatTypeConverter<Half>()] },
-                { typeof(float), [new FloatTypeConverter<float>()] },
-                { typeof(double), [new FloatTypeConverter<double>()] },
-                { typeof(decimal), [new DecimalTypeConverter()] },
-            };
+            types = DEFAULT_CONVERTERS;
         }
         else
         {

--- a/CalcExpr/Context/ExpressionContext.cs
+++ b/CalcExpr/Context/ExpressionContext.cs
@@ -1,7 +1,5 @@
-﻿using CalcExpr.Attributes;
-using CalcExpr.Expressions;
-using CalcExpr.Expressions.Collections;
-using System.Linq.Expressions;
+﻿using CalcExpr.Expressions;
+using CalcExpr.Extensions;
 using System.Reflection;
 
 namespace CalcExpr.Context;
@@ -62,15 +60,12 @@ public class ExpressionContext
                 if (!t.IsClass || t.Namespace != "CalcExpr.BuiltInFunctions")
                     continue;
 
-                foreach (MethodInfo method in t.GetMethods())
-                {
-                    if (!Function.IsValidFunction(method, out string[]? aliases))
-                        continue;
-                    
-                    Function function = new Function(method);
+                Dictionary<string[], Function> built_in_functions = t.GetFunctions();
 
-                    foreach (string alias in aliases!)
-                        funcs.Add(alias, function);
+                foreach (string[] aliases in built_in_functions.Keys)
+                {
+                    foreach (string alias in aliases)
+                        funcs.Add(alias, built_in_functions[aliases]);
                 }
             }
         }

--- a/CalcExpr/Context/ExpressionContext.cs
+++ b/CalcExpr/Context/ExpressionContext.cs
@@ -56,23 +56,6 @@ public class ExpressionContext
                 else
                     vars.Add(var, variables[var]);
 
-        if (functions is null)
-        {
-            foreach (Type t in Assembly.GetExecutingAssembly().GetTypes())
-            {
-                if (!t.IsClass || t.Namespace != "CalcExpr.BuiltInFunctions")
-                    continue;
-
-                Dictionary<string[], Function> built_in_functions = t.GetFunctions();
-
-                foreach (string[] aliases in built_in_functions.Keys)
-                {
-                    foreach (string alias in aliases)
-                        funcs.Add(alias, built_in_functions[aliases]);
-                }
-            }
-        }
-
         type_converters ??= Assembly.GetExecutingAssembly().GetTypes()
             .Where(type => type.IsClass && type.Namespace == "CalcExpr.TypeConverters" &&
                 type.IsAssignableFrom(typeof(ITypeConverter<>)))
@@ -91,6 +74,23 @@ public class ExpressionContext
                     convert_list.Add(converter);
                 else
                     types[convert_type] = [converter];
+            }
+        }
+
+        if (functions is null)
+        {
+            foreach (Type t in Assembly.GetExecutingAssembly().GetTypes())
+            {
+                if (!t.IsClass || t.Namespace != "CalcExpr.BuiltInFunctions")
+                    continue;
+
+                Dictionary<string[], Function> built_in_functions = t.GetFunctions(types.Keys);
+
+                foreach (string[] aliases in built_in_functions.Keys)
+                {
+                    foreach (string alias in aliases)
+                        funcs.Add(alias, built_in_functions[aliases]);
+                }
             }
         }
 

--- a/CalcExpr/Expressions/Components/ContextParameter.cs
+++ b/CalcExpr/Expressions/Components/ContextParameter.cs
@@ -1,0 +1,22 @@
+﻿using CalcExpr.FunctionAttributes;
+using System.Diagnostics.CodeAnalysis;
+
+namespace CalcExpr.Expressions.Components;
+
+public struct ContextParameter(IEnumerable<FunctionAttribute> attributes) : IParameter
+{
+    public FunctionAttribute[] Attributes { get; } = attributes.ToArray();
+
+    public bool AllowNull { get; } = false;
+
+    public object? ProcessArgument(IExpression argument)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int GetHashCode()
+        => HashCode.Combine(Attributes);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => obj is not null && obj is ContextParameter;
+}

--- a/CalcExpr/Expressions/Components/ContextParameter.cs
+++ b/CalcExpr/Expressions/Components/ContextParameter.cs
@@ -1,4 +1,5 @@
-﻿using CalcExpr.FunctionAttributes;
+﻿using CalcExpr.Context;
+using CalcExpr.FunctionAttributes;
 using System.Diagnostics.CodeAnalysis;
 
 namespace CalcExpr.Expressions.Components;
@@ -9,7 +10,7 @@ public struct ContextParameter(IEnumerable<FunctionAttribute> attributes) : IPar
 
     public bool AllowNull { get; } = false;
 
-    public object? ProcessArgument(IExpression argument)
+    public object? ProcessArgument(IExpression argument, ExpressionContext _)
     {
         throw new NotImplementedException();
     }

--- a/CalcExpr/Expressions/Components/Parameter.cs
+++ b/CalcExpr/Expressions/Components/Parameter.cs
@@ -2,6 +2,7 @@
 using System.Text.RegularExpressions;
 using CalcExpr.FunctionAttributes.ConditionalAttributes;
 using CalcExpr.FunctionAttributes.PreprocessAttributes;
+using CalcExpr.Context;
 
 namespace CalcExpr.Expressions.Components;
 
@@ -19,7 +20,7 @@ public readonly struct Parameter(string name, IEnumerable<FunctionAttribute> att
     public Parameter(string name, IEnumerable<string> attributes) : this(name, attributes.Select(GetAttribute))
     { }
 
-    public object? ProcessArgument(IExpression argument)
+    public object? ProcessArgument(IExpression argument, ExpressionContext _)
     {
         return IParameter.ApplyAttributes(argument, Attributes);
     }
@@ -102,7 +103,7 @@ public interface IParameter
 
     public bool AllowNull { get; }
 
-    object? ProcessArgument(IExpression argument);
+    object? ProcessArgument(IExpression argument, ExpressionContext context);
 
     public static IExpression? ApplyAttributes(IExpression argument, IEnumerable<FunctionAttribute> attributes)
     {

--- a/CalcExpr/Expressions/Components/Parameter.cs
+++ b/CalcExpr/Expressions/Components/Parameter.cs
@@ -1,10 +1,9 @@
 ﻿using CalcExpr.Context;
 using CalcExpr.FunctionAttributes;
-using CalcExpr.Parsing.Rules;
-using CalcExpr.Parsing;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using CalcExpr.FunctionAttributes.ConditionalAttributes;
+using CalcExpr.FunctionAttributes.PreprocessAttributes;
 
 namespace CalcExpr.Expressions.Components;
 
@@ -26,6 +25,24 @@ public readonly struct Parameter(string name, IEnumerable<FunctionAttribute> att
 
     public Parameter(string name, bool is_context) : this(name, [], is_context)
     { }
+
+    public IExpression? ProcessArgument(IExpression argument)
+    {
+        foreach (FunctionAttribute attribute in Attributes)
+        {
+            if (attribute is ConditionAttribute condition)
+            {
+                if (!condition.CheckCondition(argument))
+                    return null;
+            }
+            else if (attribute is PreprocessAttribute preprocess)
+            {
+                argument = preprocess.Preprocess(argument);
+            }
+        }
+
+        return argument;
+    }
 
     private static FunctionAttribute GetAttribute(string attribute)
     {

--- a/CalcExpr/Expressions/Components/TypeParameter.cs
+++ b/CalcExpr/Expressions/Components/TypeParameter.cs
@@ -1,0 +1,24 @@
+﻿using CalcExpr.FunctionAttributes;
+
+namespace CalcExpr.Expressions.Components;
+
+public struct TypeParameter(Type type, IEnumerable<FunctionAttribute> attributes, bool allow_null) : IParameter
+{
+    public readonly Type ParameterType = type;
+
+    public FunctionAttribute[] Attributes { get; } = attributes.ToArray();
+
+    public bool AllowNull { get; } = allow_null;
+
+    public object? ProcessArgument(IExpression argument)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override int GetHashCode()
+        => HashCode.Combine(ParameterType, AllowNull);
+
+    public override bool Equals(object? obj)
+        => obj is TypeParameter parameter && ParameterType == parameter.ParameterType &&
+            AllowNull == parameter.AllowNull;
+}

--- a/CalcExpr/Expressions/Components/TypeParameter.cs
+++ b/CalcExpr/Expressions/Components/TypeParameter.cs
@@ -1,24 +1,87 @@
-﻿using CalcExpr.FunctionAttributes;
+﻿using CalcExpr.Context;
+using CalcExpr.FunctionAttributes;
+using CalcExpr.TypeConverters;
+using System;
 
 namespace CalcExpr.Expressions.Components;
 
-public struct TypeParameter(Type type, IEnumerable<FunctionAttribute> attributes, bool allow_null) : IParameter
+public struct TypeParameter<T>(IEnumerable<FunctionAttribute> attributes, bool allow_null) : IParameter
 {
-    public readonly Type ParameterType = type;
+    public readonly Type ParameterType = typeof(T);
 
     public FunctionAttribute[] Attributes { get; } = attributes.ToArray();
 
     public bool AllowNull { get; } = allow_null;
 
-    public object? ProcessArgument(IExpression argument)
+    public object? ProcessArgument(IExpression argument, ExpressionContext context)
     {
-        throw new NotImplementedException();
+        IExpression? expression = IParameter.ApplyAttributes(argument, Attributes);
+        ITypeConverter[] converters = context.GetTypeConverters<T>();
+
+        return expression is null
+            ? null
+            : TypeParameter.ConvertFromExpression(converters, expression);
     }
 
     public override int GetHashCode()
         => HashCode.Combine(ParameterType, AllowNull);
 
     public override bool Equals(object? obj)
-        => obj is TypeParameter parameter && ParameterType == parameter.ParameterType &&
+        => obj is TypeParameter<T> parameter && ParameterType == parameter.ParameterType &&
             AllowNull == parameter.AllowNull;
+}
+
+public static class TypeParameter
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TypeParameter{T}"/> struct.
+    /// </summary>
+    /// <param name="type">The type of the parameter.</param>
+    /// <param name="attributes">The attributes of the parameter.</param>
+    /// <param name="allow_null">Whether the parameter allows null values.</param>
+    /// <returns>A new instance of the <see cref="TypeParameter{T}"/> struct.</returns>
+    public static object? InitializeTypeParameter(Type type, IEnumerable<FunctionAttribute> attributes, bool allow_null)
+    {
+        Type parameter_type = typeof(TypeParameter<>).MakeGenericType(type);
+
+        return Activator.CreateInstance(parameter_type, attributes, allow_null);
+    }
+
+    /// <summary>
+    /// Processes the argument with the specified context.
+    /// </summary>
+    /// <param name="converters">The <see cref="ITypeConverter"/>s to use.</param>
+    /// <param name="expression">The expression to convert.</param>
+    /// <returns>The converted object.</returns>
+    public static object? ConvertFromExpression(this IEnumerable<ITypeConverter> converters, IExpression expression)
+    {
+        foreach (ITypeConverter converter in converters)
+        {
+            object? result = converter.GetType().GetMethod("ConvertFromExpression")?.Invoke(converter, [expression]);
+
+            if (result is not null)
+                return result;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Converts the specified value to an <see cref="IExpression"/>;
+    /// </summary>
+    /// <param name="converters">The <see cref="ITypeConverter"/>s to use.</param>"/>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>An <see cref="IExpression"/> representing the value.</returns>
+    public static IExpression? ConvertToExpression(this IEnumerable<ITypeConverter> converters, object? value)
+    {
+        foreach (ITypeConverter converter in converters)
+        {
+            object? result = converter.GetType().GetMethod("ConvertToExpression")?.Invoke(converter, [value]);
+
+            if (result is not null)
+                return (IExpression?)result;
+        }
+
+        return null;
+    }
 }

--- a/CalcExpr/Expressions/Function.cs
+++ b/CalcExpr/Expressions/Function.cs
@@ -27,7 +27,7 @@ public class Function(IEnumerable<IParameter> parameters, Delegate body, bool is
     { }
 
     public Function(Delegate body, bool is_elementwise = false)
-        : this(body.Method.GetParameters().ToParameters([])!, body, is_elementwise)
+        : this(body.Method.GetParameters().ToParameters(ExpressionContext.DEFAULT_TYPES)!, body, is_elementwise)
     { }
 
     public IExpression Invoke(IExpression[] arguments, ExpressionContext context)
@@ -68,9 +68,10 @@ public class Function(IEnumerable<IParameter> parameters, Delegate body, bool is
         }
         else
         {
-            Type return_type = Body.Method.ReturnType == typeof(Nullable<>)
-                ? Body.Method.ReturnType.GetGenericArguments().Single()
-                : Body.Method.ReturnType;
+            Type return_type = Body.Method.ReturnType.IsGenericType &&
+                Body.Method.ReturnType.GetGenericTypeDefinition() == typeof(Nullable<>)
+                    ? Body.Method.ReturnType.GetGenericArguments().Single()
+                    : Body.Method.ReturnType;
             ITypeConverter[] converter = context.GetTypeConverters(return_type);
 
             return converter.ConvertToExpression(result) ?? Constant.UNDEFINED;

--- a/CalcExpr/Expressions/LambdaFunction.cs
+++ b/CalcExpr/Expressions/LambdaFunction.cs
@@ -9,8 +9,8 @@ public class LambdaFunction(IEnumerable<Parameter> parameters, IExpression body)
 
     public readonly IExpression Body = body;
 
-    public Parameter[] Parameters
-        => _parameters.ToArray();
+    public IParameter[] Parameters
+        => _parameters.Cast<IParameter>().ToArray();
 
     public bool IsElementwise
         => false;
@@ -18,16 +18,17 @@ public class LambdaFunction(IEnumerable<Parameter> parameters, IExpression body)
     public IExpression Invoke(IExpression[] arguments, ExpressionContext context)
     {
         ExpressionContext inner_context = context.Clone();
-        IExpression[]? args = ((IFunction)this).ProcessArguments(arguments);
+        IExpression[]? args = ((IFunction)this).ProcessArguments(arguments)?.Cast<IExpression>().ToArray();
 
         if (args is null)
             return Constant.UNDEFINED;
 
-        foreach ((Parameter parameter, IExpression argument) in Parameters.Zip(args))
-            inner_context[parameter.Name] = argument;
+        foreach ((IParameter parameter, IExpression? argument) in _parameters.Zip(args))
+            if (parameter is Parameter param)
+                inner_context[param.Name] = argument;
 
         IExpression result = Body.Evaluate(inner_context);
-        string[] parameters = Parameters.Select(p => p.Name).ToArray();
+        string[] parameters = _parameters.Select(p => p.Name).ToArray();
 
         foreach (string variable in inner_context.Variables)
             if (!parameters.Contains(variable))
@@ -53,7 +54,7 @@ public class LambdaFunction(IEnumerable<Parameter> parameters, IExpression body)
         if (obj is not null && obj is LambdaFunction lambda)
         {
             bool parameters_equal = lambda.Parameters.Length == Parameters.Length &&
-                (Parameters.Length == 0 || !lambda.Parameters.Select((arg, i) => arg == Parameters[i]).Any(x => !x));
+                (Parameters.Length == 0 || !lambda.Parameters.Select((arg, i) => arg.Equals(Parameters[i])).Any(x => !x));
             bool bodies_equal = lambda.Body.Equals(Body);
 
             return parameters_equal && bodies_equal;
@@ -69,5 +70,5 @@ public class LambdaFunction(IEnumerable<Parameter> parameters, IExpression body)
         => ToString(null);
 
     public string ToString(string? format)
-        => $"({String.Join(",", Parameters)})=>{Body.ToString(format)}";
+        => $"({String.Join(",", _parameters)})=>{Body.ToString(format)}";
 }

--- a/CalcExpr/Expressions/LambdaFunction.cs
+++ b/CalcExpr/Expressions/LambdaFunction.cs
@@ -18,7 +18,7 @@ public class LambdaFunction(IEnumerable<Parameter> parameters, IExpression body)
     public IExpression Invoke(IExpression[] arguments, ExpressionContext context)
     {
         ExpressionContext inner_context = context.Clone();
-        IExpression[]? args = ((IFunction)this).ProcessArguments(arguments)?.Cast<IExpression>().ToArray();
+        IExpression[]? args = ((IFunction)this).ProcessArguments(arguments, context)?.Cast<IExpression>().ToArray();
 
         if (args is null)
             return Constant.UNDEFINED;

--- a/CalcExpr/Extensions/FunctionExtensions.cs
+++ b/CalcExpr/Extensions/FunctionExtensions.cs
@@ -46,15 +46,19 @@ internal static class FunctionExtensions
                 }
                 else if (compatible_types.Contains(parameter.ParameterType))
                 {
-                    results.Add(new TypeParameter(parameter.ParameterType, attributes,
-                        parameter.ParameterType.IsClass));
+                    IParameter? p = (IParameter?)TypeParameter.InitializeTypeParameter(parameter.ParameterType,
+                        attributes, parameter.ParameterType.IsClass);
+
+                    if (p is not null)
+                        results.Add(p);
                 }
                 else if (parameter.ParameterType == typeof(Nullable<>))
                 {
                     Type type = parameter.ParameterType.GetGenericArguments()[0];
+                    IParameter? p = (IParameter?)TypeParameter.InitializeTypeParameter(type, attributes, true);
 
-                    if (compatible_types.Contains(type))
-                        results.Add(new TypeParameter(type, attributes, true));
+                    if (p is not null && compatible_types.Contains(type))
+                        results.Add(p);
                 }
             }
         }
@@ -74,8 +78,8 @@ internal static class FunctionExtensions
         {
             BuiltInFunctionAttribute? bif = method.GetCustomAttribute<BuiltInFunctionAttribute>();
 
-            if (bif is not null && method.ReturnType.IsAssignableFrom(typeof(IExpression)) ||
-                compatible_types.Contains(method.ReturnType))
+            if (bif is not null && (method.ReturnType.IsAssignableFrom(typeof(IExpression)) ||
+                compatible_types.Contains(method.ReturnType)))
             {
                 List<IParameter>? parameters = method.GetParameters().ToParameters(compatible_types);
 

--- a/CalcExpr/Extensions/FunctionExtensions.cs
+++ b/CalcExpr/Extensions/FunctionExtensions.cs
@@ -52,7 +52,8 @@ internal static class FunctionExtensions
                     if (p is not null)
                         results.Add(p);
                 }
-                else if (parameter.ParameterType == typeof(Nullable<>))
+                else if (parameter.ParameterType.IsGenericType &&
+                    parameter.ParameterType.GetGenericTypeDefinition() == typeof(Nullable<>))
                 {
                     Type type = parameter.ParameterType.GetGenericArguments()[0];
                     IParameter? p = (IParameter?)TypeParameter.InitializeTypeParameter(type, attributes, true);
@@ -76,10 +77,15 @@ internal static class FunctionExtensions
 
         foreach (MethodInfo method in type.GetMethods())
         {
+            string name = method.Name;
             BuiltInFunctionAttribute? bif = method.GetCustomAttribute<BuiltInFunctionAttribute>();
+            Type return_type = method.ReturnType.IsGenericType &&
+                method.ReturnType.GetGenericTypeDefinition() == typeof(Nullable<>)
+                    ? method.ReturnType.GetGenericArguments().Single()
+                    : method.ReturnType;
 
             if (bif is not null && (method.ReturnType.IsAssignableFrom(typeof(IExpression)) ||
-                compatible_types.Contains(method.ReturnType)))
+                compatible_types.Contains(return_type)))
             {
                 List<IParameter>? parameters = method.GetParameters().ToParameters(compatible_types);
 

--- a/CalcExpr/Extensions/FunctionExtensions.cs
+++ b/CalcExpr/Extensions/FunctionExtensions.cs
@@ -1,0 +1,101 @@
+﻿using CalcExpr.Attributes;
+using CalcExpr.Context;
+using CalcExpr.Expressions;
+using CalcExpr.Expressions.Components;
+using CalcExpr.FunctionAttributes;
+using CalcExpr.FunctionAttributes.ConditionalAttributes;
+using CalcExpr.FunctionAttributes.PreprocessAttributes;
+using System.Linq.Expressions;
+using System.Numerics;
+using System.Reflection;
+
+namespace CalcExpr.Extensions;
+
+internal static class FunctionExtensions
+{
+    public static Delegate ToDelegate(this MethodInfo method)
+    {
+        return method.CreateDelegate(Expression.GetDelegateType(method
+            .GetParameters()
+            .Select(p => p.ParameterType)
+            .Append(method.ReturnType)
+            .ToArray()));
+    }
+
+    public static List<Parameter>? ToParameters(this IEnumerable<ParameterInfo> parameters)
+    {
+        List<Parameter> results = [];
+
+        try
+        {
+            foreach (ParameterInfo parameter in parameters)
+            {
+                IEnumerable<FunctionAttribute> attributes = parameter.GetCustomAttributes(typeof(FunctionAttribute))
+                    .Cast<FunctionAttribute>();
+
+                if (parameter.ParameterType.GetInterface(nameof(IExpression)) is not null)
+                {
+                    attributes = attributes.Append(new IsExpressionTypeAttribute(parameter.ParameterType));
+                }
+                else if (parameter.ParameterType.IsAssignableFrom(typeof(IMinMaxValue<>)))
+                {
+                    int type_code = (int)Type.GetTypeCode(parameter.ParameterType.GetType());
+                    double min = Convert.ToDouble(parameter.ParameterType.GetProperty("MinValue")?
+                        .GetValue(parameter.ParameterType));
+                    double max = Convert.ToDouble(parameter.ParameterType.GetProperty("MaxValue")?
+                        .GetValue(parameter.ParameterType));
+
+                    attributes = attributes.Append(new RangeAttribute(min, max));
+
+                    if (type_code > 4 && type_code < 13)
+                        attributes = attributes.Append(new IsIntegerAttribute());
+                }
+                else if (parameter.ParameterType == typeof(bool))
+                {
+                    attributes = attributes.Append(new AsBooleanAttribute());
+                }
+
+                results.Add(new Parameter(parameter.Name!, attributes,
+                    parameter.ParameterType == typeof(ExpressionContext)));
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        return results;
+    }
+
+    public static bool IsCompatibleType(this Type type)
+    {
+        int type_code = (int)Type.GetTypeCode(type);
+
+        return typeof(IExpression).IsAssignableFrom(type) || (type_code > 4 && type_code < 16) || type == typeof(bool);
+    }
+
+    public static Dictionary<string[], Function> GetFunctions(this Type type)
+    {
+        Dictionary<string[], Function> candidates = [];
+
+        foreach (MethodInfo method in type.GetMethods())
+        {
+            BuiltInFunctionAttribute? bif = method.GetCustomAttribute<BuiltInFunctionAttribute>();
+
+            if (bif is not null && method.ReturnType.IsCompatibleType())
+            {
+                List<Parameter>? parameters = method.GetParameters().ToParameters();
+
+                if (parameters is not null)
+                {
+                    bool is_elementwise = method.GetCustomAttribute<ElementwiseAttribute>() is not null;
+                    Function function = new Function(parameters, method.ToDelegate(), is_elementwise);
+
+                    candidates[bif.Aliases] = function;
+                }
+            }
+        }
+
+        return candidates;
+    }
+}

--- a/CalcExpr/FunctionAttributes/ConditionalAttributes/IsIntegerAttribute.cs
+++ b/CalcExpr/FunctionAttributes/ConditionalAttributes/IsIntegerAttribute.cs
@@ -1,0 +1,9 @@
+﻿using CalcExpr.Expressions;
+
+namespace CalcExpr.FunctionAttributes.ConditionalAttributes;
+
+public class IsIntegerAttribute : ConditionAttribute
+{
+    public override bool CheckCondition(IExpression expression)
+        => expression is Number num && num.Value % 0 == 0;
+}

--- a/CalcExpr/TypeConverters/BooleanTypeConverter.cs
+++ b/CalcExpr/TypeConverters/BooleanTypeConverter.cs
@@ -1,0 +1,27 @@
+﻿using CalcExpr.Expressions;
+using CalcExpr.FunctionAttributes.PreprocessAttributes;
+
+namespace CalcExpr.TypeConverters;
+
+public class BooleanTypeConverter : ITypeConverter<bool?>
+{
+    public IExpression ConvertToExpression(bool? value)
+    {
+        if (value.HasValue)
+        {
+            return value.Value ? Constant.TRUE : Constant.FALSE;
+        }
+
+        return Constant.UNDEFINED;
+    }
+
+    public bool? ConvertFromExpression(IExpression expression)
+    {
+        IExpression result = new AsBooleanAttribute().Preprocess(expression);
+
+        if (Constant.UNDEFINED.Equals(result))
+            return null;
+
+        return Constant.TRUE.Equals(result);
+    }
+}

--- a/CalcExpr/TypeConverters/BooleanTypeConverter.cs
+++ b/CalcExpr/TypeConverters/BooleanTypeConverter.cs
@@ -15,8 +15,11 @@ public class BooleanTypeConverter : ITypeConverter<bool?>
         return Constant.UNDEFINED;
     }
 
-    public bool? ConvertFromExpression(IExpression expression)
+    public bool? ConvertFromExpression(IExpression? expression)
     {
+        if (expression is null)
+            return null;
+
         IExpression result = new AsBooleanAttribute().Preprocess(expression);
 
         if (Constant.UNDEFINED.Equals(result))

--- a/CalcExpr/TypeConverters/DecimalTypeConverter.cs
+++ b/CalcExpr/TypeConverters/DecimalTypeConverter.cs
@@ -18,11 +18,11 @@ public class DecimalTypeConverter : ITypeConverter<decimal?>
         return Constant.UNDEFINED;
     }
 
-    public decimal? ConvertFromExpression(IExpression expression)
+    public decimal? ConvertFromExpression(IExpression? expression)
     {
         try
         {
-            if (expression is Number num)
+            if (expression is not null && expression is Number num)
                 return Convert.ToDecimal(num.Value);
         }
         catch

--- a/CalcExpr/TypeConverters/DecimalTypeConverter.cs
+++ b/CalcExpr/TypeConverters/DecimalTypeConverter.cs
@@ -1,0 +1,34 @@
+﻿using CalcExpr.Expressions;
+
+namespace CalcExpr.TypeConverters;
+
+public class DecimalTypeConverter : ITypeConverter<decimal?>
+{
+    public IExpression ConvertToExpression(decimal? value)
+    {
+        try
+        {
+            if (value.HasValue)
+                return (Number)Convert.ToDouble(value.Value);
+        }
+        catch
+        {
+        }
+
+        return Constant.UNDEFINED;
+    }
+
+    public decimal? ConvertFromExpression(IExpression expression)
+    {
+        try
+        {
+            if (expression is Number num)
+                return Convert.ToDecimal(num.Value);
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+}

--- a/CalcExpr/TypeConverters/FloatTypeConverter.cs
+++ b/CalcExpr/TypeConverters/FloatTypeConverter.cs
@@ -11,7 +11,16 @@ public class FloatTypeConverter<T> : ITypeConverter<T?>
         try
         {
             if (value.HasValue)
+            {
+                if (T.IsPositiveInfinity(value.Value))
+                    return Constant.INFINITY;
+                else if (T.IsNegativeInfinity(value.Value))
+                    return Constant.NEGATIVE_INFINITY;
+                else if (T.IsNaN(value.Value))
+                    return Constant.UNDEFINED;
+
                 return (Number)Convert.ToDouble(value.Value);
+            }
         }
         catch
         {
@@ -20,11 +29,11 @@ public class FloatTypeConverter<T> : ITypeConverter<T?>
         return Constant.UNDEFINED;
     }
 
-    public T? ConvertFromExpression(IExpression expression)
+    public T? ConvertFromExpression(IExpression? expression)
     {
         try
         {
-            if (expression is Number num)
+            if (expression is not null && expression is Number num)
             {
                 if (num.Value > Convert.ToDouble(T.MaxValue))
                     return T.PositiveInfinity;
@@ -32,6 +41,13 @@ public class FloatTypeConverter<T> : ITypeConverter<T?>
                     return T.NegativeInfinity;
                 
                 return (T?)Convert.ChangeType(num.Value, typeof(T));
+            }
+            else if (expression is Constant)
+            {
+                if (Constant.INFINITY.Equals(expression))
+                    return T.PositiveInfinity;
+                else if (Constant.NEGATIVE_INFINITY.Equals(expression))
+                    return T.NegativeInfinity;
             }
         }
         catch

--- a/CalcExpr/TypeConverters/FloatTypeConverter.cs
+++ b/CalcExpr/TypeConverters/FloatTypeConverter.cs
@@ -1,0 +1,43 @@
+﻿using CalcExpr.Expressions;
+using System.Numerics;
+
+namespace CalcExpr.TypeConverters;
+
+public class FloatTypeConverter<T> : ITypeConverter<T?>
+    where T : struct, IFloatingPointIeee754<T>, IMinMaxValue<T>
+{
+    public IExpression ConvertToExpression(T? value)
+    {
+        try
+        {
+            if (value.HasValue)
+                return (Number)Convert.ToDouble(value.Value);
+        }
+        catch
+        {
+        }
+
+        return Constant.UNDEFINED;
+    }
+
+    public T? ConvertFromExpression(IExpression expression)
+    {
+        try
+        {
+            if (expression is Number num)
+            {
+                if (num.Value > Convert.ToDouble(T.MaxValue))
+                    return T.PositiveInfinity;
+                else if (num.Value < Convert.ToDouble(T.MinValue))
+                    return T.NegativeInfinity;
+                
+                return (T?)Convert.ChangeType(num.Value, typeof(T));
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+}

--- a/CalcExpr/TypeConverters/ITypeConverter.cs
+++ b/CalcExpr/TypeConverters/ITypeConverter.cs
@@ -2,7 +2,7 @@
 
 namespace CalcExpr.TypeConverters;
 
-public interface ITypeConverter<T>
+public interface ITypeConverter<T> : ITypeConverter
 {
     /// <summary>
     /// Converts from a value to an expression.
@@ -16,7 +16,7 @@ public interface ITypeConverter<T>
     /// </summary>
     /// <param name="expression">The expression to convert.</param>
     /// <returns>A value representing the expression.</returns>
-    T? ConvertFromExpression(IExpression expression);
+    T? ConvertFromExpression(IExpression? expression);
 }
 
 public interface ITypeConverter

--- a/CalcExpr/TypeConverters/ITypeConverter.cs
+++ b/CalcExpr/TypeConverters/ITypeConverter.cs
@@ -1,0 +1,20 @@
+﻿using CalcExpr.Expressions;
+
+namespace CalcExpr.TypeConverters;
+
+public interface ITypeConverter<T>
+{
+    /// <summary>
+    /// Converts from a value to an expression.
+    /// </summary>
+    /// <param name="value">The value to convert.</param>
+    /// <returns>An <see cref="IExpression"/> representing the value.</returns>
+    IExpression ConvertToExpression(T value);
+
+    /// <summary>
+    /// Converts from an expression to a value.
+    /// </summary>
+    /// <param name="expression">The expression to convert.</param>
+    /// <returns>A value representing the expression.</returns>
+    T? ConvertFromExpression(IExpression expression);
+}

--- a/CalcExpr/TypeConverters/ITypeConverter.cs
+++ b/CalcExpr/TypeConverters/ITypeConverter.cs
@@ -18,3 +18,7 @@ public interface ITypeConverter<T>
     /// <returns>A value representing the expression.</returns>
     T? ConvertFromExpression(IExpression expression);
 }
+
+public interface ITypeConverter
+{
+}

--- a/CalcExpr/TypeConverters/IntegerTypeConverter.cs
+++ b/CalcExpr/TypeConverters/IntegerTypeConverter.cs
@@ -20,11 +20,11 @@ public class IntegerTypeConverter<T> : ITypeConverter<T?>
         }
     }
 
-    public T? ConvertFromExpression(IExpression expression)
+    public T? ConvertFromExpression(IExpression? expression)
     {
         try
         {
-            if (expression is Number num)
+            if (expression is not null && expression is Number num)
                 return (T?)Convert.ChangeType(num.Value, typeof(T));
         }
         catch

--- a/CalcExpr/TypeConverters/IntegerTypeConverter.cs
+++ b/CalcExpr/TypeConverters/IntegerTypeConverter.cs
@@ -1,0 +1,36 @@
+﻿using CalcExpr.Expressions;
+using System.Numerics;
+
+namespace CalcExpr.TypeConverters;
+
+public class IntegerTypeConverter<T> : ITypeConverter<T?>
+    where T : struct, IBinaryInteger<T>, IMinMaxValue<T>
+{
+    public IExpression ConvertToExpression(T? value)
+    {
+        try
+        {
+            return value.HasValue
+                ? (Number)Convert.ToDouble(value.Value)
+                : Constant.UNDEFINED;
+        }
+        catch
+        {
+            return Constant.UNDEFINED;
+        }
+    }
+
+    public T? ConvertFromExpression(IExpression expression)
+    {
+        try
+        {
+            if (expression is Number num)
+                return (T?)Convert.ChangeType(num.Value, typeof(T));
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+}

--- a/TestCalcExpr/Expressions/TestFunction.cs
+++ b/TestCalcExpr/Expressions/TestFunction.cs
@@ -2,6 +2,7 @@
 using CalcExpr.Expressions.Components;
 using System.Linq.Expressions;
 using System.Reflection;
+using TestCalcExpr.Extensions;
 using TestCalcExpr.TestData;
 
 namespace TestCalcExpr.Expressions;
@@ -17,11 +18,8 @@ public class TestFunction
     {
         foreach (MethodInfo method in typeof(TestCases).GetMethods(BindingFlags.Static))
         {
-            Delegate del = method.CreateDelegate(Expression.GetDelegateType(method.GetParameters()
-                .Select(p => p.ParameterType)
-                .Concat(new Type[] { method.ReturnType })
-                .ToArray()));
-            Parameter[] parameters = method.GetParameters().Select(p => (Parameter)p).ToArray();
+            Delegate del = method.ToDelegate();
+            IParameter[] parameters = [.. method.GetParameters().ToParameters([])];
             Function function = new Function(del);
 
             Assert.AreEqual(method, function.Body.Method);

--- a/TestCalcExpr/Extensions/FunctionExtensions.cs
+++ b/TestCalcExpr/Extensions/FunctionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using CalcExpr.Attributes;
-using CalcExpr.Context;
+﻿using CalcExpr.Context;
 using CalcExpr.Expressions;
 using CalcExpr.Expressions.Components;
 using CalcExpr.FunctionAttributes;
@@ -37,7 +36,7 @@ internal static class FunctionExtensions
                     results.Add(new ContextParameter());
                     continue;
                 }
-                else if (parameter.ParameterType.IsAssignableFrom(typeof(IExpression)))
+                else if (parameter.ParameterType.IsAssignableTo(typeof(IExpression)))
                 {
                     if (parameter.ParameterType.GetInterface(nameof(IExpression)) is not null)
                         attributes = attributes.Append(new IsExpressionTypeAttribute(parameter.ParameterType));
@@ -46,15 +45,19 @@ internal static class FunctionExtensions
                 }
                 else if (compatible_types.Contains(parameter.ParameterType))
                 {
-                    results.Add(new TypeParameter(parameter.ParameterType, attributes,
-                        parameter.ParameterType.IsClass));
+                    IParameter? p = (IParameter?)TypeParameter.InitializeTypeParameter(parameter.ParameterType,
+                        attributes, parameter.ParameterType.IsClass);
+
+                    if (p is not null)
+                        results.Add(p);
                 }
                 else if (parameter.ParameterType == typeof(Nullable<>))
                 {
                     Type type = parameter.ParameterType.GetGenericArguments()[0];
+                    IParameter? p = (IParameter?)TypeParameter.InitializeTypeParameter(type, attributes, true);
 
-                    if (compatible_types.Contains(type))
-                        results.Add(new TypeParameter(type, attributes, true));
+                    if (p is not null && compatible_types.Contains(type))
+                        results.Add(p);
                 }
             }
         }

--- a/TestCalcExpr/Extensions/FunctionExtensions.cs
+++ b/TestCalcExpr/Extensions/FunctionExtensions.cs
@@ -7,7 +7,7 @@ using CalcExpr.FunctionAttributes.ConditionalAttributes;
 using System.Linq.Expressions;
 using System.Reflection;
 
-namespace CalcExpr.Extensions;
+namespace TestCalcExpr.Extensions;
 
 internal static class FunctionExtensions
 {
@@ -37,7 +37,7 @@ internal static class FunctionExtensions
                     results.Add(new ContextParameter());
                     continue;
                 }
-                else if (parameter.ParameterType.IsAssignableTo(typeof(IExpression)))
+                else if (parameter.ParameterType.IsAssignableFrom(typeof(IExpression)))
                 {
                     if (parameter.ParameterType.GetInterface(nameof(IExpression)) is not null)
                         attributes = attributes.Append(new IsExpressionTypeAttribute(parameter.ParameterType));
@@ -64,31 +64,5 @@ internal static class FunctionExtensions
         }
 
         return results;
-    }
-
-    public static Dictionary<string[], Function> GetFunctions(this Type type, IEnumerable<Type> compatible_types)
-    {
-        Dictionary<string[], Function> candidates = [];
-
-        foreach (MethodInfo method in type.GetMethods())
-        {
-            BuiltInFunctionAttribute? bif = method.GetCustomAttribute<BuiltInFunctionAttribute>();
-
-            if (bif is not null && method.ReturnType.IsAssignableFrom(typeof(IExpression)) ||
-                compatible_types.Contains(method.ReturnType))
-            {
-                List<IParameter>? parameters = method.GetParameters().ToParameters(compatible_types);
-
-                if (parameters is not null)
-                {
-                    bool is_elementwise = method.GetCustomAttribute<ElementwiseAttribute>() is not null;
-                    Function function = new Function(parameters, method.ToDelegate(), is_elementwise);
-
-                    candidates[bif.Aliases] = function;
-                }
-            }
-        }
-
-        return candidates;
     }
 }

--- a/TestCalcExpr/TestData/StatisticFunctionTestCases.cs
+++ b/TestCalcExpr/TestData/StatisticFunctionTestCases.cs
@@ -41,9 +41,9 @@ public static partial class TestCases
         new FunctionTestCase("mode", new Dictionary<IExpression, IExpression>
         {
             { TestValues.UNDEFINED, TestValues.UNDEFINED },
-            { UtilFunctions.Range<Vector>(1, 10), UtilFunctions.Range<Vector>(1, 10) },
+            { UtilFunctions.Range<Vector>(1, 10), UtilFunctions.Range<Set>(1, 10) },
             { UtilFunctions.Range<Vector>(1, 10).Map(x => (Number)(((Number)x).Value * 2)),
-                UtilFunctions.Range<Vector>(1, 10).Map(x => (Number)(((Number)x).Value * 2)) },
+                UtilFunctions.Range<Set>(1, 10).Map(x => (Number)(((Number)x).Value * 2)) },
             { new Vector([(Number)1, (Number)1, (Number)2]), (Number)1 },
         }),
         new FunctionTestCase("percentile", new Dictionary<IExpression[], IExpression>


### PR DESCRIPTION
Added support for custom types using type converters with the default supported types being booleans and the built-in number types in C#

Closes #39 