### PR TITLE
52 Update Function Registration in ExpressionContext

### DIFF
--- a/CalcExpr/Context/ExpressionContext.cs
+++ b/CalcExpr/Context/ExpressionContext.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace CalcExpr.Context;
 
-public class ExpressionContext
+public partial class ExpressionContext
 {
     internal static readonly Dictionary<Type, List<ITypeConverter>> DEFAULT_CONVERTERS =
         new Dictionary<Type, List<ITypeConverter>>
@@ -29,14 +29,10 @@ public class ExpressionContext
     internal static readonly Type[] DEFAULT_TYPES = [.. DEFAULT_CONVERTERS.Keys];
 
     private readonly Dictionary<string, IExpression> _variables;
-    private readonly Dictionary<string, IFunction> _functions;
     private readonly Dictionary<Type, List<ITypeConverter>> _type_converters;
 
     public string[] Variables
         => _variables.Keys.Concat(Functions).ToArray();
-
-    public string[] Functions
-        => _functions.Keys.ToArray();
 
     public IExpression this[string variable]
     {
@@ -46,21 +42,6 @@ public class ExpressionContext
                 ? func_value
                 : Constant.UNDEFINED;
         set => SetVariable(variable, value);
-    }
-
-    public IExpression this[string function, IEnumerable<IExpression> arguments]
-    {
-        get
-        {
-            if (ContainsFunction(function))
-            {
-                IFunction func = _functions[function];
-
-                return IFunction.ForEach(func, arguments, this);
-            }
-
-            return Constant.UNDEFINED;
-        }
     }
 
     public ExpressionContext(Dictionary<string, IExpression>? variables = null,
@@ -161,21 +142,6 @@ public class ExpressionContext
 
     public bool ContainsVariable(string name)
         => _variables.ContainsKey(name) || ContainsFunction(name);
-    
-    public bool SetFunction(string name, IFunction function)
-    {
-        if (function is null)
-            return _functions.Remove(name);
-
-        _functions[name] = function;
-        return true;
-    }
-
-    public bool RemoveFunction(string name)
-        => _functions.Remove(name);
-
-    public bool ContainsFunction(string name)
-        => _functions.ContainsKey(name);
 
     public ITypeConverter[] GetTypeConverters<T>()
         => GetTypeConverters(typeof(T));

--- a/CalcExpr/Context/ExpressionContext.cs
+++ b/CalcExpr/Context/ExpressionContext.cs
@@ -1,7 +1,5 @@
 ﻿using CalcExpr.Expressions;
-using CalcExpr.Extensions;
 using CalcExpr.TypeConverters;
-using System.Reflection;
 
 namespace CalcExpr.Context;
 
@@ -85,20 +83,12 @@ public partial class ExpressionContext
             }
         }
 
-        foreach (Type t in GetType().Assembly.GetTypes())
-        {
-            Dictionary<string[], Function> built_in_functions = t.GetFunctions(types.Keys);
-
-            foreach (string[] aliases in built_in_functions.Keys)
-            {
-                foreach (string alias in aliases)
-                    funcs.Add(alias, built_in_functions[aliases]);
-            }
-        }
-
         _type_converters = types;
         _variables = vars;
         _functions = funcs;
+
+        if (register_default_functions)
+            SetFunctions(GetType().Assembly);
     }
 
     public ExpressionContext Clone()

--- a/CalcExpr/Context/ExpressionContextFunctions.cs
+++ b/CalcExpr/Context/ExpressionContextFunctions.cs
@@ -12,19 +12,16 @@ public partial class ExpressionContext
     public string[] Functions
         => [.. _functions.Keys];
 
-    public IExpression this[string function, IEnumerable<IExpression> arguments]
+    public IExpression InvokeFunction(string function, IEnumerable<IExpression> arguments)
     {
-        get
+        if (ContainsFunction(function))
         {
-            if (ContainsFunction(function))
-            {
-                IFunction func = _functions[function];
+            IFunction func = _functions[function];
 
-                return IFunction.ForEach(func, arguments, this);
-            }
-
-            return Constant.UNDEFINED;
+            return IFunction.ForEach(func, arguments, this);
         }
+
+        return Constant.UNDEFINED;
     }
 
     public void SetFunctions(Assembly assembly)

--- a/CalcExpr/Context/ExpressionContextFunctions.cs
+++ b/CalcExpr/Context/ExpressionContextFunctions.cs
@@ -1,0 +1,41 @@
+﻿using CalcExpr.Expressions;
+
+namespace CalcExpr.Context;
+
+public partial class ExpressionContext
+{
+    private readonly Dictionary<string, IFunction> _functions;
+
+    public string[] Functions
+        => [.. _functions.Keys];
+
+    public IExpression this[string function, IEnumerable<IExpression> arguments]
+    {
+        get
+        {
+            if (ContainsFunction(function))
+            {
+                IFunction func = _functions[function];
+
+                return IFunction.ForEach(func, arguments, this);
+            }
+
+            return Constant.UNDEFINED;
+        }
+    }
+
+    public bool SetFunction(string name, IFunction function)
+    {
+        if (function is null)
+            return _functions.Remove(name);
+
+        _functions[name] = function;
+        return true;
+    }
+
+    public bool RemoveFunction(string name)
+        => _functions.Remove(name);
+
+    public bool ContainsFunction(string name)
+        => _functions.ContainsKey(name);
+}

--- a/CalcExpr/Context/ExpressionContextFunctions.cs
+++ b/CalcExpr/Context/ExpressionContextFunctions.cs
@@ -1,4 +1,7 @@
 ﻿using CalcExpr.Expressions;
+using CalcExpr.Extensions;
+using System;
+using System.Reflection;
 
 namespace CalcExpr.Context;
 
@@ -22,6 +25,28 @@ public partial class ExpressionContext
 
             return Constant.UNDEFINED;
         }
+    }
+
+    public void SetFunctions(Assembly assembly)
+    {
+        foreach (Type t in assembly.GetTypes())
+        {
+            Dictionary<string[], IFunction> built_in_functions = t.GetFunctions(_type_converters.Keys);
+
+            SetFunctions(built_in_functions);
+        }
+    }
+
+    public void SetFunctions(IEnumerable<KeyValuePair<string[], IFunction>> functions)
+    {
+        foreach (KeyValuePair<string[], IFunction> func in functions)
+            SetFunctions(func.Key.ToDictionary(k => k, k => func.Value));
+    }
+
+    public void SetFunctions(IEnumerable<KeyValuePair<string, IFunction>> functions)
+    {
+        foreach (KeyValuePair<string, IFunction> func in functions)
+            SetFunction(func.Key, func.Value);
     }
 
     public bool SetFunction(string name, IFunction function)

--- a/CalcExpr/Expressions/FunctionCall.cs
+++ b/CalcExpr/Expressions/FunctionCall.cs
@@ -15,7 +15,7 @@ public class FunctionCall(string name, IEnumerable<IExpression> arguments) : IEx
         => Evaluate(new ExpressionContext());
 
     public IExpression Evaluate(ExpressionContext context)
-        => context[Name, _arguments];
+        => context.InvokeFunction(Name, _arguments);
 
     public IExpression StepEvaluate()
         => StepEvaluate(new ExpressionContext());
@@ -36,7 +36,7 @@ public class FunctionCall(string name, IEnumerable<IExpression> arguments) : IEx
             }
         }
 
-        return context[Name, _arguments];
+        return context.InvokeFunction(Name, _arguments);
     }
 
     public override bool Equals(object? obj)

--- a/CalcExpr/Extensions/FunctionExtensions.cs
+++ b/CalcExpr/Extensions/FunctionExtensions.cs
@@ -75,7 +75,7 @@ internal static class FunctionExtensions
     {
         Dictionary<string[], Function> candidates = [];
 
-        foreach (MethodInfo method in type.GetMethods())
+        foreach (MethodInfo method in type.GetMethods().Where(x => x.IsStatic))
         {
             string name = method.Name;
             BuiltInFunctionAttribute? bif = method.GetCustomAttribute<BuiltInFunctionAttribute>();

--- a/CalcExpr/Extensions/FunctionExtensions.cs
+++ b/CalcExpr/Extensions/FunctionExtensions.cs
@@ -71,9 +71,9 @@ internal static class FunctionExtensions
         return results;
     }
 
-    public static Dictionary<string[], Function> GetFunctions(this Type type, IEnumerable<Type> compatible_types)
+    public static Dictionary<string[], IFunction> GetFunctions(this Type type, IEnumerable<Type> compatible_types)
     {
-        Dictionary<string[], Function> candidates = [];
+        Dictionary<string[], IFunction> candidates = [];
 
         foreach (MethodInfo method in type.GetMethods().Where(x => x.IsStatic))
         {

--- a/TestCalcExpr/TestExpressionContext.cs
+++ b/TestCalcExpr/TestExpressionContext.cs
@@ -10,7 +10,11 @@ public class TestExpressionContext
     [TestMethod]
     public void TestInit()
     {
-        ExpressionContext context = new ExpressionContext(TestCases.ContextVariables, TestCases.ContextFunctions);
+        ExpressionContext context = new ExpressionContext(TestCases.ContextVariables, false);
+
+        // TODO: Replace with streamlined function when created.
+        foreach (KeyValuePair<string, IFunction> func in TestCases.ContextFunctions)
+            context.SetFunction(func.Key, func.Value);
 
         foreach (string variable in TestCases.ContextVariables.Keys)
         {


### PR DESCRIPTION
Updated the `ExpressionContext` to have more options with registering functions.

Closes #52 